### PR TITLE
Add ability to export more than one `csv` file at a time

### DIFF
--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1590,6 +1590,79 @@ describe('Sync mode with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        params: {
+          email,
+          multiExport: [
+            {
+              method: 'getTradesCsv',
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles'
+            },
+            {
+              method: 'getTickersHistoryCsv',
+              symbol: 'BTC',
+              end,
+              start,
+              limit: 1000
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should not be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        params: {
+          email,
+          multiExport: [
+            {
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles'
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 500)
+    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
   it('it should be successfully performed by the getTickersHistoryCsv method', async function () {
     this.timeout(60000)
 

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const fs = require('fs')
 const { assert } = require('chai')
 const request = require('supertest')
 
@@ -18,7 +17,13 @@ const {
   connToSQLite,
   closeSQLite
 } = require('./helpers/helpers.core')
-const { createMockRESTv2SrvWithDate } = require('./helpers/helpers.mock-rest-v2')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+const {
+  testMethodOfGettingCsv,
+  testProcQueue
+} = require('./helpers/helpers.tests')
 
 const { app } = require('../app')
 const agent = request.agent(app)
@@ -1609,32 +1614,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPositionsHistoryCsv method', async function () {
@@ -1661,32 +1641,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPositionsAuditCsv method', async function () {
@@ -1714,32 +1669,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getWalletsCsv method', async function () {
@@ -1763,32 +1693,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingOfferHistoryCsv method', async function () {
@@ -1816,32 +1721,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingLoanHistoryCsv method', async function () {
@@ -1868,32 +1748,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingCreditHistoryCsv method', async function () {
@@ -1920,32 +1775,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getLedgersCsv method', async function () {
@@ -1972,32 +1802,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getTradesCsv method', async function () {
@@ -2024,32 +1829,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPublicTradesCsv method', async function () {
@@ -2077,32 +1857,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should not be successfully performed by the getPublicTradesCsv method, time frame more then a month', async function () {
@@ -2186,37 +1941,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    const file = fs.readFileSync(procRes.filePath, 'utf8')
-    const arrOfLines = file.split(/\n/)
-
-    assert.isAbove(arrOfLines.length, 2)
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method', async function () {
@@ -2242,32 +1967,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method, where amount > 0', async function () {
@@ -2294,32 +1994,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method, where amount < 0', async function () {
@@ -2346,32 +2021,7 @@ describe('Sync mode with SQLite', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
@@ -2409,23 +2059,7 @@ describe('Sync mode with SQLite', () => {
     const procPromise = queueToPromiseMulti(
       processorQueue,
       count,
-      procRes => {
-        assert.isObject(procRes)
-        assert.containsAllKeys(procRes, [
-          'userInfo',
-          'userId',
-          'name',
-          'filePath',
-          'params',
-          'isUnauth'
-        ])
-        assert.isString(procRes.userInfo)
-        assert.isString(procRes.name)
-        assert.isString(procRes.filePath)
-        assert.isObject(procRes.params)
-        assert.isBoolean(procRes.isUnauth)
-        assert.isOk(fs.existsSync(procRes.filePath))
-      }
+      testProcQueue
     )
     const aggrPromise = queueToPromiseMulti(aggregatorQueue, count)
 

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -69,6 +69,79 @@ describe('Queue', () => {
     } catch (err) { }
   })
 
+  it('it should be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        params: {
+          email,
+          multiExport: [
+            {
+              method: 'getTradesCsv',
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles'
+            },
+            {
+              method: 'getTickersHistoryCsv',
+              symbol: 'BTC',
+              end,
+              start,
+              limit: 1000
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should not be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(60000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        params: {
+          email,
+          multiExport: [
+            {
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles'
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 500)
+    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
   it('it should be successfully performed by the getTickersHistoryCsv method', async function () {
     this.timeout(60000)
 

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const fs = require('fs')
 const { assert } = require('chai')
 const request = require('supertest')
 
@@ -15,7 +14,13 @@ const {
   queueToPromise,
   queueToPromiseMulti
 } = require('./helpers/helpers.core')
-const { createMockRESTv2SrvWithDate } = require('./helpers/helpers.mock-rest-v2')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+const {
+  testMethodOfGettingCsv,
+  testProcQueue
+} = require('./helpers/helpers.tests')
 
 const { app } = require('../app')
 const agent = request.agent(app)
@@ -88,32 +93,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPositionsHistoryCsv method', async function () {
@@ -140,32 +120,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPositionsAuditCsv method', async function () {
@@ -193,32 +148,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getWalletsCsv method', async function () {
@@ -242,32 +172,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingOfferHistoryCsv method', async function () {
@@ -295,32 +200,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingLoanHistoryCsv method', async function () {
@@ -347,32 +227,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getFundingCreditHistoryCsv method', async function () {
@@ -399,32 +254,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getLedgersCsv method', async function () {
@@ -452,32 +282,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getTradesCsv method', async function () {
@@ -505,32 +310,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getPublicTradesCsv method', async function () {
@@ -558,32 +338,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should not be successfully performed by the getPublicTradesCsv method, time frame more then a month', async function () {
@@ -668,32 +423,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method', async function () {
@@ -720,32 +450,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method, where amount > 0', async function () {
@@ -773,32 +478,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getMovementsCsv method, where amount < 0', async function () {
@@ -826,32 +506,7 @@ describe('Queue', () => {
       .expect('Content-Type', /json/)
       .expect(200)
 
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
-
-    const procRes = await procPromise
-
-    assert.isObject(procRes)
-    assert.containsAllKeys(procRes, [
-      'userInfo',
-      'userId',
-      'name',
-      'filePath',
-      'params',
-      'isUnauth'
-    ])
-    assert.isString(procRes.userInfo)
-    assert.isString(procRes.name)
-    assert.isString(procRes.filePath)
-    assert.isObject(procRes.params)
-    assert.isBoolean(procRes.isUnauth)
-    assert.isOk(fs.existsSync(procRes.filePath))
-
-    await aggrPromise
-
-    assert.isNotOk(fs.existsSync(procRes.filePath))
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
@@ -890,23 +545,7 @@ describe('Queue', () => {
     const procPromise = queueToPromiseMulti(
       processorQueue,
       count,
-      procRes => {
-        assert.isObject(procRes)
-        assert.containsAllKeys(procRes, [
-          'userInfo',
-          'userId',
-          'name',
-          'filePath',
-          'params',
-          'isUnauth'
-        ])
-        assert.isString(procRes.userInfo)
-        assert.isString(procRes.name)
-        assert.isString(procRes.filePath)
-        assert.isObject(procRes.params)
-        assert.isBoolean(procRes.isUnauth)
-        assert.isOk(fs.existsSync(procRes.filePath))
-      }
+      testProcQueue
     )
     const aggrPromise = queueToPromiseMulti(aggregatorQueue, count)
 

--- a/test/4-queue-load.spec.js
+++ b/test/4-queue-load.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-const fs = require('fs')
 const { assert } = require('chai')
 const request = require('supertest')
 
@@ -14,7 +13,12 @@ const {
   rmAllFiles,
   queuesToPromiseMulti
 } = require('./helpers/helpers.core')
-const { createMockRESTv2SrvWithDate } = require('./helpers/helpers.mock-rest-v2')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+const {
+  testProcQueue
+} = require('./helpers/helpers.tests')
 
 const { app } = require('../app')
 const agent = request.agent(app)
@@ -77,23 +81,7 @@ describe('Queue load', () => {
     const procPromise = queuesToPromiseMulti(
       processorQueues,
       count,
-      procRes => {
-        assert.isObject(procRes)
-        assert.containsAllKeys(procRes, [
-          'userInfo',
-          'userId',
-          'name',
-          'filePath',
-          'params',
-          'isUnauth'
-        ])
-        assert.isString(procRes.userInfo)
-        assert.isString(procRes.name)
-        assert.isString(procRes.filePath)
-        assert.isObject(procRes.params)
-        assert.isBoolean(procRes.isUnauth)
-        assert.isOk(fs.existsSync(procRes.filePath))
-      }
+      testProcQueue
     )
     const aggrPromise = queuesToPromiseMulti(aggregatorQueues, count)
 

--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { assert } = require('chai')
+const fs = require('fs')
+
+const testProcQueue = (procRes) => {
+  assert.isObject(procRes)
+  assert.containsAllKeys(procRes, [
+    'userInfo',
+    'userId',
+    'name',
+    'email',
+    'filePaths',
+    'subParamsArr',
+    'isUnauth'
+  ])
+  assert.isString(procRes.userInfo)
+  assert.isString(procRes.name)
+  assert.isString(procRes.email)
+  assert.isArray(procRes.filePaths)
+  procRes.filePaths.forEach(filePath => {
+    assert.isString(filePath)
+    assert.isOk(fs.existsSync(filePath))
+  })
+  assert.isArray(procRes.subParamsArr)
+  procRes.subParamsArr.forEach(params => assert.isObject(params))
+  assert.isBoolean(procRes.isUnauth)
+}
+
+const testMethodOfGettingCsv = async (procPromise, aggrPromise, res) => {
+  assert.isObject(res.body)
+  assert.propertyVal(res.body, 'id', 5)
+  assert.isObject(res.body.result)
+  assert.isOk(res.body.result.isSendEmail || res.body.result.isSaveLocaly)
+
+  const procRes = await procPromise
+
+  testProcQueue(procRes)
+
+  await aggrPromise
+
+  procRes.filePaths.forEach(filePath => {
+    assert.isNotOk(fs.existsSync(filePath))
+  })
+}
+
+module.exports = {
+  testMethodOfGettingCsv,
+  testProcQueue
+}

--- a/workers/api.service.report.wrk.js
+++ b/workers/api.service.report.wrk.js
@@ -203,6 +203,12 @@ class WrkReportServiceApi extends WrkApi {
           const data = _.cloneDeep(job.data)
           delete data.columnsCsv
 
+          if (Array.isArray(data.jobsData)) {
+            data.jobsData.forEach(item => {
+              delete item.columnsCsv
+            })
+          }
+
           processorQueue.addJob({
             ...data,
             isUnauth: true

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -23,8 +23,15 @@ class UpdateSyncQueueJobError extends BaseError {
   }
 }
 
+class FindMethodToGetCsvFileError extends BaseError {
+  constructor (message = 'ERR_METHOD_TO_GET_CSV_FILE_NOT_FOUND') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   CollSyncPermissionError,
-  UpdateSyncQueueJobError
+  UpdateSyncQueueJobError,
+  FindMethodToGetCsvFileError
 }

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -3,13 +3,48 @@
 const {
   checkParams,
   getCsvArgs,
-  checkTimeLimit
+  checkTimeLimit,
+  hasJobInQueueWithStatusBy
 } = require('./index')
 const { FindMethodToGetCsvFileError } = require('../errors')
 
+const _checkJobAndGetUserData = async (
+  reportService,
+  args,
+  uId,
+  uInfo
+) => {
+  const userId = Number.isInteger(uId)
+    ? uId
+    : await hasJobInQueueWithStatusBy(reportService, args)
+  const userInfo = uInfo && typeof uInfo === 'string'
+    ? uInfo
+    : await reportService._getUsername(args)
+
+  return {
+    userId,
+    userInfo
+  }
+}
+
 const getCsvJobData = {
-  getTradesCsvJobData (args, userId, userInfo) {
+  async getTradesCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'trades')
 
@@ -37,8 +72,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getTickersHistoryCsvJobData (args, userId, userInfo) {
+  async getTickersHistoryCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args, 'paramsSchemaForCsv', ['symbol'])
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'tickersHistory')
     const symb = Array.isArray(args.params.symbol)
@@ -84,8 +134,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getWalletsCsvJobData (args, userId, userInfo) {
+  async getWalletsCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args, 'paramsSchemaForWalletsCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const jobData = {
       userInfo,
@@ -102,8 +167,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getPositionsHistoryCsvJobData (args, userId, userInfo) {
+  async getPositionsHistoryCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'positionsHistory')
 
@@ -137,8 +217,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getPositionsAuditCsvJobData (args, userId, userInfo) {
+  async getPositionsAuditCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args, 'paramsSchemaForPositionsAuditCsv', ['id'])
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'positionsAudit')
 
@@ -172,9 +267,24 @@ const getCsvJobData = {
 
     return jobData
   },
-  getPublicTradesCsvJobData (args, userId, userInfo) {
+  async getPublicTradesCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args, 'paramsSchemaForPublicTradesCsv', ['symbol'])
     checkTimeLimit(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'publicTrades')
 
@@ -199,8 +309,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getLedgersCsvJobData (args, userId, userInfo) {
+  async getLedgersCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'ledgers')
 
@@ -225,8 +350,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getOrdersCsvJobData (args, userId, userInfo) {
+  async getOrdersCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'orders')
 
@@ -257,8 +397,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getMovementsCsvJobData (args, userId, userInfo) {
+  async getMovementsCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'movements')
 
@@ -284,8 +439,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getFundingOfferHistoryCsvJobData (args, userId, userInfo) {
+  async getFundingOfferHistoryCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'fundingOfferHistory')
 
@@ -316,8 +486,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getFundingLoanHistoryCsvJobData (args, userId, userInfo) {
+  async getFundingLoanHistoryCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'fundingLoanHistory')
 
@@ -350,8 +535,23 @@ const getCsvJobData = {
 
     return jobData
   },
-  getFundingCreditHistoryCsvJobData (args, userId, userInfo) {
+  async getFundingCreditHistoryCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
     checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await _checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
 
     const csvArgs = getCsvArgs(args, 'fundingCreditHistory')
 
@@ -387,15 +587,27 @@ const getCsvJobData = {
   }
 }
 
-const getMultipleCsvJobData = (
+const getMultipleCsvJobData = async (
   reportService,
   args,
-  userId,
-  userInfo
+  uId,
+  uInfo
 ) => {
   checkParams(args, 'paramsSchemaForMultipleCsv', false, true)
 
-  const jobsData = args.params.multiExport.map(params => {
+  const {
+    userId,
+    userInfo
+  } = await _checkJobAndGetUserData(
+    reportService,
+    args,
+    uId,
+    uInfo
+  )
+
+  const jobsData = []
+
+  for (const params of args.params.multiExport) {
     const getJobDataMethodName = `${params.method}JobData`
     const hasGetJobDataMethod = Object.keys(getCsvJobData).every((name) => {
       return name !== getJobDataMethodName
@@ -408,7 +620,8 @@ const getMultipleCsvJobData = (
       throw new FindMethodToGetCsvFileError()
     }
 
-    return getCsvJobData[getJobDataMethodName].bind(getCsvJobData)(
+    const jobData = await getCsvJobData[getJobDataMethodName](
+      reportService,
       {
         ...args,
         params: { ...params }
@@ -416,7 +629,9 @@ const getMultipleCsvJobData = (
       userId,
       userInfo
     )
-  })
+
+    jobsData.push(jobData)
+  }
 
   return {
     userInfo,

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const {
+  checkParams,
+  getCsvArgs
+} = require('./index')
+const { FindMethodToGetCsvFileError } = require('../errors')
+
+const getCsvJobData = {
+  getTradesCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'trades')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getTrades',
+      args: csvArgs,
+      propNameForPagination: 'mtsCreate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        execAmount: 'AMOUNT',
+        execPrice: 'PRICE',
+        fee: 'FEE',
+        feeCurrency: 'FEE CURRENCY',
+        mtsCreate: 'DATE',
+        orderID: 'ORDER ID'
+      },
+      formatSettings: {
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
+  getTickersHistoryCsvJobData (args, userId, userInfo) {
+    checkParams(args, 'paramsSchemaForCsv', ['symbol'])
+
+    const csvArgs = getCsvArgs(args, 'tickersHistory')
+    const symb = Array.isArray(args.params.symbol)
+      ? args.params.symbol
+      : [args.params.symbol]
+    const isTrading = symb.every(s => {
+      return s && typeof s === 'string' && s[0] === 't'
+    })
+    const isFunding = symb.every(s => {
+      return s && typeof s === 'string' && s[0] !== 't'
+    })
+
+    if (!isTrading && !isFunding) {
+      throw new Error('ERR_SYMBOLS_ARE_NOT_OF_SAME_TYPE')
+    }
+
+    const tTickerHistColumns = {
+      symbol: 'PAIR',
+      bid: 'BID',
+      ask: 'ASK',
+      mtsUpdate: 'TIME'
+    }
+    const fTickerHistColumns = {
+      symbol: 'PAIR',
+      bid: 'BID',
+      bidPeriod: 'BID PERIOD',
+      ask: 'ASK',
+      mtsUpdate: 'TIME'
+    }
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getTickersHistory',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: isTrading ? tTickerHistColumns : fTickerHistColumns,
+      formatSettings: {
+        mtsUpdate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  }
+}
+
+const getMultipleCsvJobData = (
+  reportService,
+  args,
+  userId,
+  userInfo
+) => {
+  checkParams(args, 'paramsSchemaForMultipleCsv') // TODO: schema not implement
+
+  const jobsData = args.params.map(params => {
+    const getJobDataMethodName = `${params.method}JobData`
+    const hasGetJobDataMethod = Object.keys(getCsvJobData).every((name) => {
+      return name !== getJobDataMethodName
+    })
+
+    if (
+      hasGetJobDataMethod ||
+      typeof reportService[params.method] !== 'function'
+    ) {
+      throw new FindMethodToGetCsvFileError()
+    }
+
+    return getCsvJobData[getJobDataMethodName].bind(getCsvJobData)(
+      {
+        ...args,
+        params: { ...params }
+      },
+      userId,
+      userInfo
+    )
+  })
+
+  return {
+    userInfo,
+    userId,
+    name: 'getMultiple',
+    args,
+    jobsData
+  }
+}
+
+module.exports = {
+  ...getCsvJobData,
+  getMultipleCsvJobData
+}

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -224,6 +224,38 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getOrdersCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'orders')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getOrders',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        type: 'TYPE',
+        amountOrig: 'AMOUNT',
+        amountExecuted: 'EXECUTED AMOUNT',
+        price: 'PRICE',
+        priceAvg: 'AVERAGE EXECUTION PRICE',
+        mtsCreate: 'CREATED',
+        mtsUpdate: 'UPDATED',
+        status: 'STATUS'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -315,6 +315,40 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getFundingLoanHistoryCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'fundingLoanHistory')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getFundingLoanHistory',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'CURRENCY',
+        side: 'SIDE',
+        amount: 'AMOUNT',
+        status: 'STATUS',
+        rate: 'RATE',
+        period: 'PERIOD',
+        mtsOpening: 'OPENED',
+        mtsLastPayout: 'CLOSED',
+        mtsUpdate: 'DATE'
+      },
+      formatSettings: {
+        side: 'side',
+        mtsUpdate: 'date',
+        mtsOpening: 'date',
+        mtsLastPayout: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -93,7 +93,7 @@ const getMultipleCsvJobData = (
 ) => {
   checkParams(args, 'paramsSchemaForMultipleCsv') // TODO: schema not implement
 
-  const jobsData = args.params.map(params => {
+  const jobsData = args.params.multiExport.map(params => {
     const getJobDataMethodName = `${params.method}JobData`
     const hasGetJobDataMethod = Object.keys(getCsvJobData).every((name) => {
       return name !== getJobDataMethodName

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -256,6 +256,33 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getMovementsCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'movements')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getMovements',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdated',
+      columnsCsv: {
+        id: '#',
+        mtsUpdated: 'DATE',
+        currency: 'CURRENCY',
+        status: 'STATUS',
+        amount: 'AMOUNT',
+        fees: 'FEES',
+        destinationAddress: 'DESCRIPTION'
+      },
+      formatSettings: {
+        mtsUpdated: 'date'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -283,6 +283,38 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getFundingOfferHistoryCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'fundingOfferHistory')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getFundingOfferHistory',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'CURRENCY',
+        amountOrig: 'AMOUNT',
+        amountExecuted: 'EXECUTED AMOUNT',
+        type: 'TYPE',
+        status: 'STATUS',
+        rate: 'RATE',
+        period: 'PERIOD',
+        mtsUpdate: 'UPDATED',
+        mtsCreate: 'CREATED'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -82,6 +82,24 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getWalletsCsvJobData (args, userId, userInfo) {
+    checkParams(args, 'paramsSchemaForWalletsCsv')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getWallets',
+      args,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        type: 'TYPE',
+        currency: 'CURRENCY',
+        balance: 'BALANCE'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -349,6 +349,41 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getFundingCreditHistoryCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'fundingCreditHistory')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getFundingCreditHistory',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'CURRENCY',
+        amount: 'AMOUNT',
+        rate: 'RATE',
+        period: 'PERIOD',
+        mtsOpening: 'OPENED',
+        mtsLastPayout: 'CLOSED',
+        mtsUpdate: 'DATE',
+        side: 'SIDE',
+        status: 'STATUS',
+        positionPair: 'POSITION PAIR'
+      },
+      formatSettings: {
+        side: 'side',
+        mtsUpdate: 'date',
+        mtsOpening: 'date',
+        mtsLastPayout: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -2,7 +2,8 @@
 
 const {
   checkParams,
-  getCsvArgs
+  getCsvArgs,
+  checkTimeLimit
 } = require('./index')
 const { FindMethodToGetCsvFileError } = require('../errors')
 
@@ -165,6 +166,33 @@ const getCsvJobData = {
       formatSettings: {
         mtsUpdate: 'date',
         mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
+  getPublicTradesCsvJobData (args, userId, userInfo) {
+    checkParams(args, 'paramsSchemaForPublicTradesCsv', ['symbol'])
+    checkTimeLimit(args)
+
+    const csvArgs = getCsvArgs(args, 'publicTrades')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getPublicTrades',
+      args: csvArgs,
+      propNameForPagination: 'mts',
+      columnsCsv: {
+        id: '#',
+        mts: 'TIME',
+        price: 'PRICE',
+        amount: 'AMOUNT',
+        symbol: 'PAIR'
+      },
+      formatSettings: {
+        mts: 'date',
         symbol: 'symbol'
       }
     }

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -100,6 +100,41 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getPositionsHistoryCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'positionsHistory')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getPositionsHistory',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        amount: 'AMOUNT',
+        basePrice: 'BASE PRICE',
+        liquidationPrice: 'LIQ PRICE',
+        pl: 'P/L',
+        plPerc: 'P/L%',
+        marginFunding: 'FUNDING COST',
+        marginFundingType: 'FUNDING TYPE',
+        status: 'STATUS',
+        mtsUpdate: 'UPDATED',
+        mtsCreate: 'CREATED',
+        leverage: 'LEVERAGE'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -198,6 +198,32 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getLedgersCsvJobData (args, userId, userInfo) {
+    checkParams(args)
+
+    const csvArgs = getCsvArgs(args, 'ledgers')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getLedgers',
+      args: csvArgs,
+      propNameForPagination: 'mts',
+      columnsCsv: {
+        description: 'DESCRIPTION',
+        currency: 'CURRENCY',
+        amount: 'AMOUNT',
+        balance: 'BALANCE',
+        mts: 'DATE',
+        wallet: 'WALLET'
+      },
+      formatSettings: {
+        mts: 'date'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -135,6 +135,41 @@ const getCsvJobData = {
     }
 
     return jobData
+  },
+  getPositionsAuditCsvJobData (args, userId, userInfo) {
+    checkParams(args, 'paramsSchemaForPositionsAuditCsv', ['id'])
+
+    const csvArgs = getCsvArgs(args, 'positionsAudit')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getPositionsAudit',
+      args: csvArgs,
+      propNameForPagination: 'mtsUpdate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        amount: 'AMOUNT',
+        basePrice: 'BASE PRICE',
+        liquidationPrice: 'LIQ PRICE',
+        pl: 'P/L',
+        plPerc: 'P/L%',
+        marginFunding: 'FUNDING COST',
+        marginFundingType: 'FUNDING TYPE',
+        status: 'STATUS',
+        mtsUpdate: 'UPDATED',
+        mtsCreate: 'CREATED',
+        leverage: 'LEVERAGE'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/getCsvJobData.js
+++ b/workers/loc.api/helpers/getCsvJobData.js
@@ -91,7 +91,7 @@ const getMultipleCsvJobData = (
   userId,
   userInfo
 ) => {
-  checkParams(args, 'paramsSchemaForMultipleCsv') // TODO: schema not implement
+  checkParams(args, 'paramsSchemaForMultipleCsv', false, true)
 
   const jobsData = args.params.multiExport.map(params => {
     const getJobDataMethodName = `${params.method}JobData`

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -221,7 +221,12 @@ const checkParamsAuth = (args) => {
 }
 
 const getCsvStoreStatus = async (reportService, args) => {
-  if (!args.params || typeof args.params.email !== 'string') {
+  if (
+    !args.params ||
+    typeof args.params !== 'object' ||
+    !args.params.email ||
+    typeof args.params.email !== 'string'
+  ) {
     return { isSaveLocaly: true }
   }
 

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -155,7 +155,8 @@ const getParams = (
 const checkParams = (
   args,
   schemaName = 'paramsSchemaForCsv',
-  requireFields = []
+  requireFields = [],
+  checkParamsField = false
 ) => {
   const ajv = new Ajv()
 
@@ -183,7 +184,7 @@ const checkParams = (
   }
 
   if (
-    args.params &&
+    (checkParamsField || args.params) &&
     !ajv.validate(_schema, args.params)
   ) {
     throw new Error(`ERR_ARGS_NO_PARAMS ${JSON.stringify(ajv.errors)}`)

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -144,6 +144,29 @@ const paramsSchemaForWalletsCsv = {
   }
 }
 
+const paramsSchemaForMultipleCsv = {
+  type: 'object',
+  required: ['multiExport'],
+  properties: {
+    email: {
+      type: 'string'
+    },
+    multiExport: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        type: 'object',
+        required: ['method'],
+        properties: {
+          method: {
+            type: 'string'
+          }
+        }
+      }
+    }
+  }
+}
+
 module.exports = {
   paramsSchemaForApi,
   paramsSchemaForCsv,
@@ -153,5 +176,6 @@ module.exports = {
   paramsSchemaForPositionsAudit,
   paramsSchemaForPositionsAuditCsv,
   paramsSchemaForWallets,
-  paramsSchemaForWalletsCsv
+  paramsSchemaForWalletsCsv,
+  paramsSchemaForMultipleCsv
 }

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -479,7 +479,7 @@ const _getCompleteFileName = (
   const _ext = ext ? `.${ext}` : ''
   const _userInfo = userInfo ? `${userInfo}_` : ''
   const fileName = queueName === 'getWallets' || isMultiExport
-    ? `${_userInfo}${baseName}_MOMENT_${isMultiExport ? timestamp : formattedDateNow}${_ext}`
+    ? `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${_ext}`
     : `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${_ext}`
 
   return fileName

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -284,24 +284,24 @@ const _setDefaultPrams = (args) => {
     : 0
 }
 
-const writeDataToStream = async (reportService, stream, job) => {
-  if (typeof job === 'string') {
-    _writeMessageToStream(reportService, stream, job)
+const writeDataToStream = async (reportService, stream, jobData) => {
+  if (typeof jobData === 'string') {
+    _writeMessageToStream(reportService, stream, jobData)
 
     return
   }
 
-  const method = job.data.name
+  const method = jobData.name
 
   if (typeof reportService[method] !== 'function') {
     throw new Error('ERR_METHOD_NOT_FOUND')
   }
 
   const queue = reportService.ctx.lokue_aggregator.q
-  const propName = job.data.propNameForPagination
-  const formatSettings = job.data.formatSettings
+  const propName = jobData.propNameForPagination
+  const formatSettings = jobData.formatSettings
 
-  const _args = _.cloneDeep(job.data.args)
+  const _args = _.cloneDeep(jobData.args)
 
   _setDefaultPrams(_args)
   const currIterationArgs = _.cloneDeep(_args)

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -16,54 +16,63 @@ const { isAuthError } = require('../helpers')
 let reportService = null
 
 module.exports = async job => {
-  let filePath = null
+  const filePaths = []
   const processorQueue = reportService.ctx.lokue_processor.q
+  const isUnauth = job.data.isUnauth || false
+  const jobsData = Array.isArray(job.data.jobsData)
+    ? job.data.jobsData
+    : [job.data]
 
   try {
-    if (
-      !job.data.args.params &&
-      typeof job.data.args.params !== 'object'
-    ) {
-      job.data.args.params = {}
+    for (const data of jobsData) {
+      if (
+        !data.args.params &&
+        typeof data.args.params !== 'object'
+      ) {
+        job.data.args.params = {}
+      }
+
+      const filePath = await createUniqueFileName()
+      filePaths.push(filePath)
+
+      const write = isUnauth
+        ? 'Your file could not be completed, please try again'
+        : data
+
+      const writable = fs.createWriteStream(filePath)
+      const writablePromise = writableToPromise(writable)
+      const stringifier = stringify({
+        header: true,
+        columns: job.data.columnsCsv
+      })
+
+      stringifier.pipe(writable)
+
+      await writeDataToStream(
+        reportService,
+        stringifier,
+        write
+      )
+
+      stringifier.end()
+
+      await writablePromise
     }
-
-    filePath = await createUniqueFileName()
-
-    const isUnauth = job.data.isUnauth || false
-    const write = isUnauth
-      ? 'Your file could not be completed, please try again'
-      : job
-    const writable = fs.createWriteStream(filePath)
-    const writablePromise = writableToPromise(writable)
-    const stringifier = stringify({
-      header: true,
-      columns: job.data.columnsCsv
-    })
-
-    stringifier.pipe(writable)
-
-    await writeDataToStream(
-      reportService,
-      stringifier,
-      write
-    )
-
-    stringifier.end()
-
-    await writablePromise
 
     job.done()
     processorQueue.emit('completed', {
       userInfo: job.data.userInfo,
       userId: job.data.userId,
       name: job.data.name,
-      filePath,
-      params: job.data.args.params,
+      filePaths,
+      params: jobsData.map(data => data.args.params),
       isUnauth
     })
   } catch (err) {
     try {
-      await unlink(filePath)
+      for (const filePath of filePaths) {
+        await unlink(filePath)
+      }
     } catch (err) {
       processorQueue.emit('error:unlink', job)
     }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -18,8 +18,9 @@ const {
 const {
   getTradesCsvJobData,
   getTickersHistoryCsvJobData,
+  getWalletsCsvJobData,
   getMultipleCsvJobData
-} = require ('./helpers/getCsvJobData')
+} = require('./helpers/getCsvJobData')
 
 class ReportService extends Api {
   space (service, msg) {
@@ -348,7 +349,7 @@ class ReportService extends Api {
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
-      
+
       cb(null, status)
     } catch (err) {
       this._err(err, 'getMultipleCsv', cb)
@@ -389,25 +390,11 @@ class ReportService extends Api {
 
   async getWalletsCsv (space, args, cb) {
     try {
-      checkParams(args, 'paramsSchemaForWalletsCsv')
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const method = 'getWallets'
+      const jobData = getWalletsCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: method,
-        args,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          type: 'TYPE',
-          currency: 'CURRENCY',
-          balance: 'BALANCE'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -25,6 +25,7 @@ const {
   getOrdersCsvJobData,
   getMovementsCsvJobData,
   getFundingOfferHistoryCsvJobData,
+  getFundingLoanHistoryCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -524,39 +525,11 @@ class ReportService extends Api {
 
   async getFundingLoanHistoryCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'fundingLoanHistory')
+      const jobData = getFundingLoanHistoryCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getFundingLoanHistory',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'CURRENCY',
-          side: 'SIDE',
-          amount: 'AMOUNT',
-          status: 'STATUS',
-          rate: 'RATE',
-          period: 'PERIOD',
-          mtsOpening: 'OPENED',
-          mtsLastPayout: 'CLOSED',
-          mtsUpdate: 'DATE'
-        },
-        formatSettings: {
-          side: 'side',
-          mtsUpdate: 'date',
-          mtsOpening: 'date',
-          mtsLastPayout: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -339,13 +339,12 @@ class ReportService extends Api {
     }
   }
 
-  // TODO:
   async getMultipleCsv (space, args, cb) {
     try {
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-      const jobData = getMultipleCsvJobData(this, args, userId, userInfo) // TODO:
+      const jobData = getMultipleCsvJobData(this, args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -361,7 +360,7 @@ class ReportService extends Api {
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-      const jobData = getTradesCsvJobData(args, userId, userInfo) // TODO:
+      const jobData = getTradesCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -377,7 +376,7 @@ class ReportService extends Api {
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-      const jobData = getTickersHistoryCsvJobData(args, userId, userInfo) // TODO:
+      const jobData = getTickersHistoryCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -19,6 +19,7 @@ const {
   getTradesCsvJobData,
   getTickersHistoryCsvJobData,
   getWalletsCsvJobData,
+  getPositionsHistoryCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -406,40 +407,11 @@ class ReportService extends Api {
 
   async getPositionsHistoryCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'positionsHistory')
+      const jobData = getPositionsHistoryCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getPositionsHistory',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'PAIR',
-          amount: 'AMOUNT',
-          basePrice: 'BASE PRICE',
-          liquidationPrice: 'LIQ PRICE',
-          pl: 'P/L',
-          plPerc: 'P/L%',
-          marginFunding: 'FUNDING COST',
-          marginFundingType: 'FUNDING TYPE',
-          status: 'STATUS',
-          mtsUpdate: 'UPDATED',
-          mtsCreate: 'CREATED',
-          leverage: 'LEVERAGE'
-        },
-        formatSettings: {
-          mtsUpdate: 'date',
-          mtsCreate: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -21,6 +21,7 @@ const {
   getPositionsHistoryCsvJobData,
   getPositionsAuditCsvJobData,
   getPublicTradesCsvJobData,
+  getLedgersCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -456,31 +457,11 @@ class ReportService extends Api {
 
   async getLedgersCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'ledgers')
+      const jobData = getLedgersCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getLedgers',
-        args: csvArgs,
-        propNameForPagination: 'mts',
-        columnsCsv: {
-          description: 'DESCRIPTION',
-          currency: 'CURRENCY',
-          amount: 'AMOUNT',
-          balance: 'BALANCE',
-          mts: 'DATE',
-          wallet: 'WALLET'
-        },
-        formatSettings: {
-          mts: 'date'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,8 +11,7 @@ const {
   parseFields,
   accountCache,
   getTimezoneConf,
-  prepareApiResponse,
-  getCsvArgs
+  prepareApiResponse
 } = require('./helpers')
 const {
   getTradesCsvJobData,
@@ -26,6 +25,7 @@ const {
   getMovementsCsvJobData,
   getFundingOfferHistoryCsvJobData,
   getFundingLoanHistoryCsvJobData,
+  getFundingCreditHistoryCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -541,40 +541,11 @@ class ReportService extends Api {
 
   async getFundingCreditHistoryCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'fundingCreditHistory')
+      const jobData = getFundingCreditHistoryCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getFundingCreditHistory',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'CURRENCY',
-          amount: 'AMOUNT',
-          rate: 'RATE',
-          period: 'PERIOD',
-          mtsOpening: 'OPENED',
-          mtsLastPayout: 'CLOSED',
-          mtsUpdate: 'DATE',
-          side: 'SIDE',
-          status: 'STATUS',
-          positionPair: 'POSITION PAIR'
-        },
-        formatSettings: {
-          side: 'side',
-          mtsUpdate: 'date',
-          mtsOpening: 'date',
-          mtsLastPayout: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -6,7 +6,6 @@ const {
   getREST,
   checkParams,
   getCsvStoreStatus,
-  hasJobInQueueWithStatusBy,
   toString,
   parseFields,
   accountCache,
@@ -27,7 +26,7 @@ const {
   getFundingLoanHistoryCsvJobData,
   getFundingCreditHistoryCsvJobData,
   getMultipleCsvJobData
-} = require('./helpers/getCsvJobData')
+} = require('./helpers/get-csv-job-data')
 
 class ReportService extends Api {
   space (service, msg) {
@@ -349,10 +348,8 @@ class ReportService extends Api {
 
   async getMultipleCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getMultipleCsvJobData(this, args, userId, userInfo)
+      const jobData = await getMultipleCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -365,10 +362,8 @@ class ReportService extends Api {
 
   async getTradesCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getTradesCsvJobData(args, userId, userInfo)
+      const jobData = await getTradesCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -381,10 +376,8 @@ class ReportService extends Api {
 
   async getTickersHistoryCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getTickersHistoryCsvJobData(args, userId, userInfo)
+      const jobData = await getTickersHistoryCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -397,10 +390,8 @@ class ReportService extends Api {
 
   async getWalletsCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getWalletsCsvJobData(args, userId, userInfo)
+      const jobData = await getWalletsCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -413,10 +404,8 @@ class ReportService extends Api {
 
   async getPositionsHistoryCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getPositionsHistoryCsvJobData(args, userId, userInfo)
+      const jobData = await getPositionsHistoryCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -429,10 +418,8 @@ class ReportService extends Api {
 
   async getPositionsAuditCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getPositionsAuditCsvJobData(args, userId, userInfo)
+      const jobData = await getPositionsAuditCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -445,10 +432,8 @@ class ReportService extends Api {
 
   async getPublicTradesCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getPublicTradesCsvJobData(args, userId, userInfo)
+      const jobData = await getPublicTradesCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -461,10 +446,8 @@ class ReportService extends Api {
 
   async getLedgersCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getLedgersCsvJobData(args, userId, userInfo)
+      const jobData = await getLedgersCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -477,10 +460,8 @@ class ReportService extends Api {
 
   async getOrdersCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getOrdersCsvJobData(args, userId, userInfo)
+      const jobData = await getOrdersCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -493,10 +474,8 @@ class ReportService extends Api {
 
   async getMovementsCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getMovementsCsvJobData(args, userId, userInfo)
+      const jobData = await getMovementsCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -509,10 +488,8 @@ class ReportService extends Api {
 
   async getFundingOfferHistoryCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getFundingOfferHistoryCsvJobData(args, userId, userInfo)
+      const jobData = await getFundingOfferHistoryCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -525,10 +502,8 @@ class ReportService extends Api {
 
   async getFundingLoanHistoryCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getFundingLoanHistoryCsvJobData(args, userId, userInfo)
+      const jobData = await getFundingLoanHistoryCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)
@@ -541,10 +516,8 @@ class ReportService extends Api {
 
   async getFundingCreditHistoryCsv (space, args, cb) {
     try {
-      const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
-      const userInfo = await this._getUsername(args)
-      const jobData = getFundingCreditHistoryCsvJobData(args, userId, userInfo)
+      const jobData = await getFundingCreditHistoryCsvJobData(this, args)
       const processorQueue = this.ctx.lokue_processor.q
 
       processorQueue.addJob(jobData)

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -22,6 +22,7 @@ const {
   getPositionsAuditCsvJobData,
   getPublicTradesCsvJobData,
   getLedgersCsvJobData,
+  getOrdersCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -473,37 +474,11 @@ class ReportService extends Api {
 
   async getOrdersCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'orders')
+      const jobData = getOrdersCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getOrders',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'PAIR',
-          type: 'TYPE',
-          amountOrig: 'AMOUNT',
-          amountExecuted: 'EXECUTED AMOUNT',
-          price: 'PRICE',
-          priceAvg: 'AVERAGE EXECUTION PRICE',
-          mtsCreate: 'CREATED',
-          mtsUpdate: 'UPDATED',
-          status: 'STATUS'
-        },
-        formatSettings: {
-          mtsUpdate: 'date',
-          mtsCreate: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -20,6 +20,7 @@ const {
   getTickersHistoryCsvJobData,
   getWalletsCsvJobData,
   getPositionsHistoryCsvJobData,
+  getPositionsAuditCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -423,40 +424,11 @@ class ReportService extends Api {
 
   async getPositionsAuditCsv (space, args, cb) {
     try {
-      checkParams(args, 'paramsSchemaForPositionsAuditCsv', ['id'])
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'positionsAudit')
+      const jobData = getPositionsAuditCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getPositionsAudit',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'PAIR',
-          amount: 'AMOUNT',
-          basePrice: 'BASE PRICE',
-          liquidationPrice: 'LIQ PRICE',
-          pl: 'P/L',
-          plPerc: 'P/L%',
-          marginFunding: 'FUNDING COST',
-          marginFundingType: 'FUNDING TYPE',
-          status: 'STATUS',
-          mtsUpdate: 'UPDATED',
-          mtsCreate: 'CREATED',
-          leverage: 'LEVERAGE'
-        },
-        formatSettings: {
-          mtsUpdate: 'date',
-          mtsCreate: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -23,6 +23,7 @@ const {
   getPublicTradesCsvJobData,
   getLedgersCsvJobData,
   getOrdersCsvJobData,
+  getMovementsCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -490,32 +491,11 @@ class ReportService extends Api {
 
   async getMovementsCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'movements')
+      const jobData = getMovementsCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getMovements',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdated',
-        columnsCsv: {
-          id: '#',
-          mtsUpdated: 'DATE',
-          currency: 'CURRENCY',
-          status: 'STATUS',
-          amount: 'AMOUNT',
-          fees: 'FEES',
-          destinationAddress: 'DESCRIPTION'
-        },
-        formatSettings: {
-          mtsUpdated: 'date'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -24,6 +24,7 @@ const {
   getLedgersCsvJobData,
   getOrdersCsvJobData,
   getMovementsCsvJobData,
+  getFundingOfferHistoryCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -507,37 +508,11 @@ class ReportService extends Api {
 
   async getFundingOfferHistoryCsv (space, args, cb) {
     try {
-      checkParams(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'fundingOfferHistory')
+      const jobData = getFundingOfferHistoryCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getFundingOfferHistory',
-        args: csvArgs,
-        propNameForPagination: 'mtsUpdate',
-        columnsCsv: {
-          id: '#',
-          symbol: 'CURRENCY',
-          amountOrig: 'AMOUNT',
-          amountExecuted: 'EXECUTED AMOUNT',
-          type: 'TYPE',
-          status: 'STATUS',
-          rate: 'RATE',
-          period: 'PERIOD',
-          mtsUpdate: 'UPDATED',
-          mtsCreate: 'CREATED'
-        },
-        formatSettings: {
-          mtsUpdate: 'date',
-          mtsCreate: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,7 +11,6 @@ const {
   parseFields,
   accountCache,
   getTimezoneConf,
-  checkTimeLimit,
   prepareApiResponse,
   getCsvArgs
 } = require('./helpers')
@@ -21,6 +20,7 @@ const {
   getWalletsCsvJobData,
   getPositionsHistoryCsvJobData,
   getPositionsAuditCsvJobData,
+  getPublicTradesCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/getCsvJobData')
 
@@ -440,32 +440,11 @@ class ReportService extends Api {
 
   async getPublicTradesCsv (space, args, cb) {
     try {
-      checkParams(args, 'paramsSchemaForPublicTradesCsv', ['symbol'])
-      checkTimeLimit(args)
       const userId = await hasJobInQueueWithStatusBy(this, args)
       const status = await getCsvStoreStatus(this, args)
       const userInfo = await this._getUsername(args)
-
-      const csvArgs = getCsvArgs(args, 'publicTrades')
+      const jobData = getPublicTradesCsvJobData(args, userId, userInfo)
       const processorQueue = this.ctx.lokue_processor.q
-      const jobData = {
-        userInfo,
-        userId,
-        name: 'getPublicTrades',
-        args: csvArgs,
-        propNameForPagination: 'mts',
-        columnsCsv: {
-          id: '#',
-          mts: 'TIME',
-          price: 'PRICE',
-          amount: 'AMOUNT',
-          symbol: 'PAIR'
-        },
-        formatSettings: {
-          mts: 'date',
-          symbol: 'symbol'
-        }
-      }
 
       processorQueue.addJob(jobData)
 


### PR DESCRIPTION
This PR adds the ability to export more than one `csv` file at a time with a single call to the `getMultipleCsv` method

Example:
  - call the `getMultipleCsv` method and pass params array:
```
{
    "auth": {
        "apiKey": "fake",
        "apiSecret": "fake"
    },
    "method": "getMultipleCsv",
    "params": {
        "email": "fake@email.fake",
        "multiExport": [
            {
                "method": "getTradesCsv",
                "symbol": "tBTCUSD",
                "end": 1546765168000
            },
            {
                "method": "getLedgersCsv",
                "symbol": "BTC",
                "end": 1546765168000,
                "timezone": "America/Los_Angeles"
            }
        ]
    }
}
```
  - if `syncMode: false` in `config/service.report.json` then all files will be zipped and emailed:
`username_multiple-exports_MOMENT_2019-01-16T15-06-41.803Z.zip`
  - if `syncMode: true` in `./config/service.report.json` then all files will be saved locally in `./csv` directory:
`username_ledgers_FROM_Thu-Jan-01-1970_TO_Sun-Jan-06-2019_ON_2019-01-30T15-14-26.137Z.csv`
`username_trades_FROM_Thu-Jan-01-1970_TO_Sun-Jan-06-2019_ON_2019-01-30T15-14-26.135Z.csv`