### PR TITLE
Add wallets to sync mode

### DIFF
--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -116,8 +116,8 @@ const createMockRESTv2SrvWithDate = (
   limit = null,
   opts = {
     'tickers_hist': { limit: 250 },
-    'wallets_hist': { limit: 100 },
-    'wallets': { limit: 100 },
+    'wallets_hist': { limit: 100, isNotMoreThanLimit: true },
+    'wallets': { limit: 100, isNotMoreThanLimit: true },
     'positions_hist': { limit: 50 },
     'positions_audit': { limit: 250 },
     'ledgers': { limit: 500 },
@@ -145,7 +145,7 @@ const createMockRESTv2SrvWithDate = (
       return
     }
 
-    const _limit = limit || val.limit
+    const _limit = limit && !val.isNotMoreThanLimit ? limit : val.limit
     const step = (end - start) / _limit
     let date = start
     let id = 12345

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -746,6 +746,10 @@ class MediatorReportService extends ReportService {
     return promisify(super.getFundingCreditHistory.bind(this))(null, args)
   }
 
+  _getWallets (args) {
+    return promisify(super.getWallets.bind(this))(null, args)
+  }
+
   async _checkAuthInApi (args) {
     checkParamsAuth(args)
 

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -706,6 +706,38 @@ class MediatorReportService extends ReportService {
     }
   }
 
+  /**
+   * TODO: need to add a mix `wallets` and `ledgers`
+   * @override
+   */
+  async getWallets (space, args, cb) {
+    try {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        super.getWallets(space, args, cb)
+
+        return
+      }
+
+      checkParams(args, 'paramsSchemaForWallets')
+
+      if (
+        args.params &&
+        typeof args.params === 'object'
+      ) {
+        args.params = pick(args.params, ['end'])
+      }
+
+      const res = await this.dao.findInCollBy(
+        '_getWallets',
+        args
+      )
+
+      cb(null, res)
+    } catch (err) {
+      cb(err)
+    }
+  }
+
   _getTickersHistory (args) {
     return promisify(super.getTickersHistory.bind(this))(null, args)
   }

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -14,6 +14,7 @@ module.exports = {
   FUNDING_CREDIT_HISTORY: 'fundingCreditHistory',
   TICKERS_HISTORY: 'tickersHistory',
   POSITIONS_HISTORY: 'positionsHistory',
+  WALLETS: 'wallets',
   SYMBOLS: 'symbols',
   CURRENCIES: 'currencies'
 }

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -455,6 +455,12 @@ class SqliteDAO extends DAO {
       where,
       values
     } = this._getWhereQuery(filter)
+    const group = (
+      Array.isArray(methodColl.groupResBy) &&
+      methodColl.groupResBy.length > 0
+    )
+      ? `GROUP BY ${methodColl.groupResBy.join(', ')}`
+      : ''
 
     if (params.limit) {
       values.$limit = params.limit
@@ -471,6 +477,7 @@ class SqliteDAO extends DAO {
 
     const sql = `SELECT ${fields.join(', ')} FROM ${methodColl.name}
       ${where}
+      ${group}
       ${sort}
       ${limit}`
 

--- a/workers/loc.api/sync/data.inserter.js
+++ b/workers/loc.api/sync/data.inserter.js
@@ -574,8 +574,11 @@ class DataInserter extends EventEmitter {
 
     const _args = _.cloneDeep(args)
     const currIterationArgs = _.cloneDeep(_args)
+    let count = 0
 
     while (true) {
+      count += 1
+
       const date = new Date(currIterationArgs.params.end)
       const utcDate = new Date(Date.UTC(
         date.getUTCFullYear(),
@@ -631,7 +634,7 @@ class DataInserter extends EventEmitter {
         uData
       )
 
-      await delay(180000)
+      if (count > 3) await delay(180000)
     }
   }
 

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -250,6 +250,25 @@ const _models = new Map([
     }
   ],
   [
+    ALLOWED_COLLS.WALLETS,
+    {
+      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      type: 'VARCHAR(255)',
+      currency: 'VARCHAR(255)',
+      balance: 'DECIMAL(22,12)',
+      unsettledInterest: 'DECIMAL(22,12)',
+      balanceAvailable: 'DECIMAL(22,12)',
+      placeHolder: 'TEXT',
+      mtsUpdate: 'BIGINT',
+      user_id: `INT NOT NULL,
+        CONSTRAINT wallets_fk_#{field}
+        FOREIGN KEY (#{field})
+        REFERENCES users(_id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE`
+    }
+  ],
+  [
     'publicСollsСonf',
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -485,6 +485,22 @@ const _methodCollMap = new Map([
     }
   ],
   [
+    '_getWallets',
+    {
+      name: ALLOWED_COLLS.WALLETS,
+      maxLimit: null,
+      dateFieldName: 'mtsUpdate',
+      symbolFieldName: 'currency',
+      sort: [['mtsUpdate', -1]],
+      groupResBy: ['type', 'currency'],
+      hasNewData: false,
+      start: 0,
+      type: 'insertable:array:objects',
+      fieldsOfUniqueIndex: ['type', 'currency', 'mtsUpdate'],
+      model: { ..._models.get(ALLOWED_COLLS.WALLETS) }
+    }
+  ],
+  [
     '_getSymbols',
     {
       name: ALLOWED_COLLS.SYMBOLS,


### PR DESCRIPTION
This PR adds `wallets` to the sync mode.
The `api_v2` `wallets/hist` endpoint returns the history of the wallet in the 00:00:00 (`HH:MM:SS`) UTC of a certain data.
For the first time running the sync wallets, we should sync stepping by date with an interval of 24 hours `currIterationArgs.params.end = currIterationArgs.params.end - 24h`. And if the user makes a request with precision `HH:MM:SS` then we need to respond with `wallets` data adding the missing part from `ledgers`