### PR TITLE
Fix exported csv file name

### DIFF
--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -539,7 +539,7 @@ const uploadS3 = async (
   const deflateFac = wrk.deflate_gzip
   const isMultiExport = (
     queueName === 'getMultiple' ||
-    (Array.isArray(subParamsArr) && subParamsArr.length > 0)
+    (Array.isArray(subParamsArr) && subParamsArr.length > 1)
   )
   const fileNameWithoutExt = _getCompleteFileName(
     subParamsArr[0].name,


### PR DESCRIPTION
This PR fixes exported csv file name. When exporting one file there was the name as if it was a multiple export