### PR TITLE
Refactor DataInserter

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -23,8 +23,26 @@ class UpdateSyncQueueJobError extends BaseError {
   }
 }
 
-class FindMethodToGetCsvFileError extends BaseError {
+class FindMethodError extends BaseError {
+  constructor (message = 'ERR_METHOD_NOT_FOUND') {
+    super(message)
+  }
+}
+
+class FindMethodToGetCsvFileError extends FindMethodError {
   constructor (message = 'ERR_METHOD_TO_GET_CSV_FILE_NOT_FOUND') {
+    super(message)
+  }
+}
+
+class AsyncProgressHandlerIsNotFnError extends BaseError {
+  constructor (message = 'ERR_ASYNC_PROGRESS_HANDLER_IS_NOT_FUNCTION') {
+    super(message)
+  }
+}
+
+class AfterAllInsertsHookIsNotFnError extends BaseError {
+  constructor (message = 'ERR_AFTER_ALL_INSERTS_HOOK_IS_NOT_FUNCTION') {
     super(message)
   }
 }
@@ -33,5 +51,8 @@ module.exports = {
   BaseError,
   CollSyncPermissionError,
   UpdateSyncQueueJobError,
-  FindMethodToGetCsvFileError
+  FindMethodError,
+  FindMethodToGetCsvFileError,
+  AsyncProgressHandlerIsNotFnError,
+  AfterAllInsertsHookIsNotFnError
 }

--- a/workers/loc.api/sync/data.inserter/api.middleware.js
+++ b/workers/loc.api/sync/data.inserter/api.middleware.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const ApiMiddlewareHandlerAfter = require('./api.middleware.handler.after')
+const { FindMethodError } = require('../../errors')
 
 class ApiMiddleware {
   constructor (
@@ -36,7 +37,7 @@ class ApiMiddleware {
 
   _requestToReportService (method, args) {
     if (!this.hasMethod(method)) {
-      throw new Error('ERR_METHOD_NOT_FOUND')
+      throw new FindMethodError()
     }
 
     const fn = this.reportService[method].bind(this.reportService)

--- a/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
+++ b/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const { getMethodCollMap } = require('../../schema')
+const ALLOWED_COLLS = require('../../allowed.colls')
+
+const _reduceMethodCollMap = (
+  _methodCollMap,
+  res,
+  cb = () => true
+) => {
+  return [..._methodCollMap].reduce((accum, curr) => {
+    if (
+      accum.every(item => item.name !== curr[1].name) &&
+      res.every(item => item.name !== curr[1].name) &&
+      cb(curr)
+    ) {
+      accum.push(curr)
+    }
+
+    return accum
+  }, [])
+}
+
+const _isPubColl = (coll) => {
+  return /^public:.*/i.test(coll[1].type)
+}
+
+const _isAllowedColl = (coll, allowedCollsNames) => {
+  return allowedCollsNames.some(item => item === coll[1].name)
+}
+
+module.exports = (
+  methodCollMap,
+  syncColls,
+  allowedCollsNames
+) => {
+  const res = []
+  const _methodCollMap = (methodCollMap instanceof Map)
+    ? new Map(methodCollMap)
+    : getMethodCollMap()
+
+  for (const collName of syncColls) {
+    if (collName === ALLOWED_COLLS.ALL) {
+      const subRes = _reduceMethodCollMap(
+        _methodCollMap,
+        res,
+        coll => _isAllowedColl(coll, allowedCollsNames)
+      )
+
+      res.push(...subRes)
+
+      break
+    }
+    if (collName === ALLOWED_COLLS.PUBLIC) {
+      const subRes = _reduceMethodCollMap(
+        _methodCollMap,
+        res,
+        coll => (
+          (_isAllowedColl(coll, allowedCollsNames) &&
+          _isPubColl(coll))
+        )
+      )
+
+      res.push(...subRes)
+
+      continue
+    }
+    if (collName === ALLOWED_COLLS.PRIVATE) {
+      const subRes = _reduceMethodCollMap(
+        _methodCollMap,
+        res,
+        coll => (
+          (_isAllowedColl(coll, allowedCollsNames) &&
+          !_isPubColl(coll))
+        )
+      )
+
+      res.push(...subRes)
+
+      continue
+    }
+
+    const subRes = _reduceMethodCollMap(
+      _methodCollMap,
+      res,
+      curr => curr[1].name === collName
+    )
+
+    res.push(...subRes)
+  }
+
+  return new Map(res)
+}

--- a/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
+++ b/workers/loc.api/sync/data.inserter/helpers/filter-method-coll-map-by-list.js
@@ -6,13 +6,13 @@ const ALLOWED_COLLS = require('../../allowed.colls')
 const _reduceMethodCollMap = (
   _methodCollMap,
   res,
-  cb = () => true
+  isAllowed = () => true
 ) => {
   return [..._methodCollMap].reduce((accum, curr) => {
     if (
       accum.every(item => item.name !== curr[1].name) &&
       res.every(item => item.name !== curr[1].name) &&
-      cb(curr)
+      isAllowed(curr)
     ) {
       accum.push(curr)
     }

--- a/workers/loc.api/sync/data.inserter/helpers/index.js
+++ b/workers/loc.api/sync/data.inserter/helpers/index.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const searchClosePriceAndSumAmount = require(
+  './search-close-price-and-sum-amount'
+)
+const filterMethodCollMapByList = require(
+  './filter-method-coll-map-by-list'
+)
+const {
+  invertSort,
+  filterMethodCollMap,
+  checkCollType,
+  compareElemsDbAndApi,
+  normalizeApiData,
+  getAuthFromDb,
+  getAllowedCollsNames
+} = require('./utils')
+
+module.exports = {
+  searchClosePriceAndSumAmount,
+  filterMethodCollMapByList,
+  invertSort,
+  filterMethodCollMap,
+  checkCollType,
+  compareElemsDbAndApi,
+  normalizeApiData,
+  getAuthFromDb,
+  getAllowedCollsNames
+}

--- a/workers/loc.api/sync/data.inserter/helpers/search-close-price-and-sum-amount.js
+++ b/workers/loc.api/sync/data.inserter/helpers/search-close-price-and-sum-amount.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const searchClosePriceAndSumAmount = async (
+module.exports = async (
   dao,
   {
     auth,
@@ -91,8 +91,4 @@ const searchClosePriceAndSumAmount = async (
     closePrice,
     sumAmount: null
   }
-}
-
-module.exports = {
-  searchClosePriceAndSumAmount
 }

--- a/workers/loc.api/sync/data.inserter/helpers/utils.js
+++ b/workers/loc.api/sync/data.inserter/helpers/utils.js
@@ -1,0 +1,111 @@
+'use strict'
+
+const {
+  pick,
+  isEmpty
+} = require('lodash')
+
+const invertSort = (sortArr) => {
+  return sortArr.map(item => {
+    const _arr = [ ...item ]
+
+    _arr[1] = item[1] > 0 ? -1 : 1
+
+    return _arr
+  })
+}
+
+const filterMethodCollMap = (
+  methodCollMap,
+  isPublic
+) => {
+  return new Map([...methodCollMap].filter(([key, schema]) => {
+    const _isPub = /^public:.*/i.test(schema.type)
+
+    return schema.hasNewData && (isPublic ? _isPub : !_isPub)
+  }))
+}
+
+const checkCollType = (
+  type,
+  coll,
+  isPublic
+) => {
+  const _pub = isPublic ? 'public:' : ''
+  const regExp = new RegExp(`^${_pub}${type}$`, 'i')
+
+  return regExp.test(coll.type)
+}
+
+const compareElemsDbAndApi = (
+  dateFieldName,
+  elDb,
+  elApi
+) => {
+  const _elDb = Array.isArray(elDb) ? elDb[0] : elDb
+  const _elApi = Array.isArray(elApi) ? elApi[0] : elApi
+
+  return (_elDb[dateFieldName] < _elApi[dateFieldName])
+    ? _elDb[dateFieldName]
+    : false
+}
+
+const normalizeApiData = (
+  data = [],
+  model,
+  cb = () => {}
+) => {
+  return data.map(item => {
+    if (
+      typeof item !== 'object' ||
+      typeof model !== 'object' ||
+      Object.keys(model).length === 0
+    ) {
+      return item
+    }
+
+    cb(item)
+
+    return pick(item, Object.keys(model))
+  })
+}
+
+const getAuthFromDb = async (dao) => {
+  try {
+    const users = await dao.getActiveUsers()
+    const auth = new Map()
+
+    if (isEmpty(users)) {
+      return auth
+    }
+
+    users.forEach(user => {
+      auth.set(
+        user.apiKey,
+        {
+          apiKey: user.apiKey,
+          apiSecret: user.apiSecret
+        }
+      )
+    })
+
+    return auth
+  } catch (err) {
+    return null
+  }
+}
+
+const getAllowedCollsNames = (allowedColls) => {
+  return Object.values(allowedColls)
+    .filter(name => !(/^_.*/.test(name)))
+}
+
+module.exports = {
+  invertSort,
+  filterMethodCollMap,
+  checkCollType,
+  compareElemsDbAndApi,
+  normalizeApiData,
+  getAuthFromDb,
+  getAllowedCollsNames
+}

--- a/workers/loc.api/sync/data.inserter/index.js
+++ b/workers/loc.api/sync/data.inserter/index.js
@@ -26,6 +26,11 @@ const {
 } = require('../../helpers')
 const ALLOWED_COLLS = require('../allowed.colls')
 const ApiMiddleware = require('./api.middleware')
+const {
+  FindMethodError,
+  AsyncProgressHandlerIsNotFnError,
+  AfterAllInsertsHookIsNotFnError
+} = require('../../errors')
 
 const MESS_ERR_UNAUTH = 'ERR_AUTH_UNAUTHORIZED'
 
@@ -65,7 +70,7 @@ class DataInserter extends EventEmitter {
 
   setAsyncProgressHandler (cb) {
     if (typeof cb !== 'function') {
-      throw new Error('ERR_ASYNC_PROGRESS_HANDLER_IS_NOT_FUNCTION')
+      throw new AsyncProgressHandlerIsNotFnError()
     }
 
     this._asyncProgressHandler = cb
@@ -127,7 +132,7 @@ class DataInserter extends EventEmitter {
 
   addAfterAllInsertsHooks (hook) {
     if (typeof hook !== 'function') {
-      throw new Error('ERR_AFTER_ALL_INSERTS_HOOK_IS_NOT_FUNCTION')
+      throw new AfterAllInsertsHookIsNotFnError()
     }
     if (!Array.isArray(this._afterAllInsertsHooks)) {
       this._afterAllInsertsHooks = []
@@ -412,7 +417,7 @@ class DataInserter extends EventEmitter {
 
   async _getDataFromApi (methodApi, args, isCheckCall) {
     if (!this.apiMiddleware.hasMethod(methodApi)) {
-      throw new Error('ERR_METHOD_NOT_FOUND')
+      throw new FindMethodError()
     }
 
     let countRateLimitError = 0


### PR DESCRIPTION
This PR splits the `DataInserter` module `workers/loc.api/sync/data.inserter` into different helper modules and moves errors to errors module

### Dependencies:
* With this PR need to merge this PR: [bitfinexcom/bfx-reports-framework#3](https://github.com/bitfinexcom/bfx-reports-framework/pull/3)