### PR TITLE
Change public trades model

### DIFF
--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -339,19 +339,31 @@ const getCsvJobData = {
 
     const csvArgs = getCsvArgs(args, 'publicTrades')
 
+    const isTradingPair = csvArgs.params.symbol.startsWith('t')
+    const columnsCsv = (isTradingPair)
+      ? {
+        id: '#',
+        mts: 'TIME',
+        price: 'PRICE',
+        amount: 'AMOUNT',
+        symbol: 'PAIR'
+      }
+      : {
+        id: '#',
+        mts: 'TIME',
+        rate: 'RATE',
+        amount: 'AMOUNT',
+        period: 'PERIOD',
+        symbol: 'PAIR'
+      }
+
     const jobData = {
       userInfo,
       userId,
       name: 'getPublicTrades',
       args: csvArgs,
       propNameForPagination: 'mts',
-      columnsCsv: {
-        id: '#',
-        mts: 'TIME',
-        price: 'PRICE',
-        amount: 'AMOUNT',
-        symbol: 'PAIR'
-      },
+      columnsCsv,
       formatSettings: {
         mts: 'date',
         symbol: 'symbol'

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -354,7 +354,7 @@ const getCsvJobData = {
         rate: 'RATE',
         amount: 'AMOUNT',
         period: 'PERIOD',
-        symbol: 'PAIR'
+        symbol: 'CURRENCY'
       }
 
     const jobData = {

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -339,7 +339,9 @@ const getCsvJobData = {
 
     const csvArgs = getCsvArgs(args, 'publicTrades')
 
-    const isTradingPair = csvArgs.params.symbol.startsWith('t')
+    const isTradingPair = Array.isArray(csvArgs.params.symbol)
+      ? csvArgs.params.symbol[0].startsWith('t')
+      : csvArgs.params.symbol.startsWith('t')
     const columnsCsv = (isTradingPair)
       ? {
         id: '#',

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -67,6 +67,8 @@ const _models = new Map([
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
       id: 'BIGINT',
       mts: 'BIGINT',
+      rate: 'DECIMAL(22,12)',
+      period: 'BIGINT',
       amount: 'DECIMAL(22,12)',
       price: 'DECIMAL(22,12)',
       _symbol: 'VARCHAR(255)'


### PR DESCRIPTION
This PR:
  - changes public trades model for supporting public funding
  - changes the name of the public funding symbol field csv
  - fixes checking isTradingPair for supporting symbol array