### PR TITLE
Add active orders report

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -960,6 +960,50 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getActiveOrders method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrders',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+
+    const resItem = res.body.result[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'gid',
+      'cid',
+      'symbol',
+      'mtsCreate',
+      'mtsUpdate',
+      'amount',
+      'amountOrig',
+      'type',
+      'typePrev',
+      'flags',
+      'status',
+      'price',
+      'priceAvg',
+      'priceTrailing',
+      'priceAuxLimit',
+      'notify',
+      'placedId',
+      'amountExecuted'
+    ])
+  })
+
   it('it should be successfully performed by the getMovements method', async function () {
     this.timeout(5000)
 

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1413,6 +1413,50 @@ describe('Sync mode with SQLite', () => {
     ])
   })
 
+  it('it should be successfully performed by the getActiveOrders method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrders',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+
+    const resItem = res.body.result[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'gid',
+      'cid',
+      'symbol',
+      'mtsCreate',
+      'mtsUpdate',
+      'amount',
+      'amountOrig',
+      'type',
+      'typePrev',
+      'flags',
+      'status',
+      'price',
+      'priceAvg',
+      'priceTrailing',
+      'priceAuxLimit',
+      'notify',
+      'placedId',
+      'amountExecuted'
+    ])
+  })
+
   it('it should be successfully performed by the getMovements method', async function () {
     this.timeout(5000)
 
@@ -1980,6 +2024,29 @@ describe('Sync mode with SQLite', () => {
           symbol: 'tBTCUSD',
           end,
           start,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the getActiveOrdersCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrdersCsv',
+        params: {
           email
         },
         id: 5

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -523,6 +523,29 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getActiveOrdersCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrdersCsv',
+        params: {
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getMovementsCsv method', async function () {
     this.timeout(3 * 60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -88,6 +88,12 @@ const setDataTo = (
       dataItem[5] = _date
       break
 
+    case 'active_orders':
+      dataItem[0] = id
+      dataItem[4] = _date
+      dataItem[5] = _date
+      break
+
     case 'movements':
       dataItem[0] = id
       dataItem[5] = _date
@@ -127,6 +133,7 @@ const getMockDataOpts = () => ({
   trades: { limit: 1000 },
   public_trades: { limit: 5000 },
   orders: { limit: 500 },
+  active_orders: { limit: 100 },
   movements: { limit: 25 },
   f_offer_hist: { limit: 500 },
   f_loan_hist: { limit: 500 },

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -33,7 +33,7 @@ const setDataTo = (
   {
     date = Date.now(),
     id = 12345,
-    fee = 0.1
+    fee = -0.0001
   } = {}
 ) => {
   const _date = Math.round(date)
@@ -149,11 +149,13 @@ const createMockRESTv2SrvWithDate = (
   const srv = _createMockRESTv2Srv()
 
   Object.entries(opts).forEach(([key, val]) => {
+    const mockData = _getMockData(key)
+
     if (
-      !Array.isArray(_getMockData(key)[0]) ||
+      !Array.isArray(mockData[0]) ||
       val === null
     ) {
-      srv.setResponse(key, _getMockData(key).slice())
+      srv.setResponse(key, [...mockData])
 
       return
     }
@@ -165,15 +167,17 @@ const createMockRESTv2SrvWithDate = (
     let fee = 0.1
 
     const data = Array(_limit).fill(null).map((item, i) => {
-      if (_limit === (i + 1)) {
+      if (_limit === (i + mockData.length)) {
         date = end
-      } else if (i > 0) {
+      } else if (i + 1 > mockData.length) {
         date += step
+      }
+      if (i > 0) {
         id += 1
-        fee += 0.1
+        fee -= 0.0001
       }
 
-      const dataItem = _getMockData(key)[0].slice()
+      const dataItem = [...mockData[i % mockData.length]]
       _setDataTo(
         key,
         dataItem,

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -5,7 +5,7 @@ const _ms = Date.now()
 module.exports = new Map([
   [
     'symbols',
-    [
+    [[
       'btcusd',
       'ethusd',
       'ethbtc',
@@ -17,7 +17,7 @@ module.exports = new Map([
       'ifxusd',
       'ioteur',
       'euxusx'
-    ]
+    ]]
   ],
   [
     'user_info',

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -203,6 +203,37 @@ module.exports = new Map([
     ]]
   ],
   [
+    'active_orders',
+    [[
+      12345,
+      12345,
+      12345,
+      'tBTCUSD',
+      _ms,
+      _ms,
+      0,
+      0.01,
+      'EXCHANGE LIMIT',
+      null,
+      null,
+      null,
+      '0',
+      'EXECUTED @ 15065.0(0.01)',
+      null,
+      null,
+      12345,
+      12345,
+      12345,
+      12345,
+      null,
+      null,
+      null,
+      false,
+      null,
+      null
+    ]]
+  ],
+  [
     'movements',
     [[
       12345,

--- a/workers/loc.api/helpers/check-job-and-get-user-data.js
+++ b/workers/loc.api/helpers/check-job-and-get-user-data.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const hasJobInQueueWithStatusBy = require(
+  './has-job-in-queue-with-status-by'
+)
+
+module.exports = async (
+  reportService,
+  args,
+  uId,
+  uInfo
+) => {
+  const userId = Number.isInteger(uId)
+    ? uId
+    : await hasJobInQueueWithStatusBy(reportService, args)
+  const userInfo = uInfo && typeof uInfo === 'string'
+    ? uInfo
+    : await reportService._getUsername(args)
+
+  return {
+    userId,
+    userInfo
+  }
+}

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -1,34 +1,17 @@
 'use strict'
 
+const { omit } = require('lodash')
+
 const {
   checkParams,
   getCsvArgs,
   checkTimeLimit,
-  hasJobInQueueWithStatusBy
+  checkJobAndGetUserData
 } = require('./index')
 const {
   FindMethodToGetCsvFileError,
   SymbolsTypeError
 } = require('../errors')
-
-const _checkJobAndGetUserData = async (
-  reportService,
-  args,
-  uId,
-  uInfo
-) => {
-  const userId = Number.isInteger(uId)
-    ? uId
-    : await hasJobInQueueWithStatusBy(reportService, args)
-  const userInfo = uInfo && typeof uInfo === 'string'
-    ? uInfo
-    : await reportService._getUsername(args)
-
-  return {
-    userId,
-    userInfo
-  }
-}
 
 const getCsvJobData = {
   async getTradesCsvJobData (
@@ -42,7 +25,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -86,7 +69,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -148,7 +131,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -181,7 +164,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -231,7 +214,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -279,7 +262,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -330,7 +313,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -385,7 +368,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -426,7 +409,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -473,7 +456,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -516,7 +499,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -563,7 +546,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -612,7 +595,7 @@ const getCsvJobData = {
     const {
       userId,
       userInfo
-    } = await _checkJobAndGetUserData(
+    } = await checkJobAndGetUserData(
       reportService,
       args,
       uId,
@@ -655,27 +638,33 @@ const getCsvJobData = {
 
 const getMultipleCsvJobData = async (
   reportService,
-  args,
+  incomingArgs,
   uId,
   uInfo
 ) => {
+  const args = omit(incomingArgs, ['getCsvJobData'])
+
   checkParams(args, 'paramsSchemaForMultipleCsv', false, true)
 
   const {
     userId,
     userInfo
-  } = await _checkJobAndGetUserData(
+  } = await checkJobAndGetUserData(
     reportService,
     args,
     uId,
     uInfo
   )
 
+  const _getCsvJobData = {
+    ...getCsvJobData,
+    ...incomingArgs.getCsvJobData
+  }
   const jobsData = []
 
   for (const params of args.params.multiExport) {
     const getJobDataMethodName = `${params.method}JobData`
-    const hasGetJobDataMethod = Object.keys(getCsvJobData).every((name) => {
+    const hasGetJobDataMethod = Object.keys(_getCsvJobData).every((name) => {
       return name !== getJobDataMethodName
     })
 
@@ -686,7 +675,7 @@ const getMultipleCsvJobData = async (
       throw new FindMethodToGetCsvFileError()
     }
 
-    const jobData = await getCsvJobData[getJobDataMethodName](
+    const jobData = await _getCsvJobData[getJobDataMethodName](
       reportService,
       {
         ...args,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -445,6 +445,53 @@ const getCsvJobData = {
 
     return jobData
   },
+  async getActiveOrdersCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getActiveOrders',
+      args,
+      propNameForPagination: null,
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        type: 'TYPE',
+        typePrev: 'PREVIOUS ORDER TYPE',
+        amountOrig: 'AMOUNT',
+        amountExecuted: 'EXECUTED AMOUNT',
+        price: 'PRICE',
+        priceAvg: 'AVERAGE EXECUTION PRICE',
+        priceTrailing: 'TRAILING PRICE',
+        mtsCreate: 'CREATED',
+        mtsUpdate: 'UPDATED',
+        status: 'STATUS'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
   async getMovementsCsvJobData (
     reportService,
     args,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -428,10 +428,12 @@ const getCsvJobData = {
         id: '#',
         symbol: 'PAIR',
         type: 'TYPE',
+        typePrev: 'PREVIOUS ORDER TYPE',
         amountOrig: 'AMOUNT',
         amountExecuted: 'EXECUTED AMOUNT',
         price: 'PRICE',
         priceAvg: 'AVERAGE EXECUTION PRICE',
+        priceTrailing: 'TRAILING PRICE',
         mtsCreate: 'CREATED',
         mtsUpdate: 'UPDATED',
         status: 'STATUS'

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -37,6 +37,9 @@ const {
   mapObjBySchema,
   emptyRes
 } = require('./utils')
+const checkJobAndGetUserData = require(
+  './check-job-and-get-user-data'
+)
 
 module.exports = {
   getREST,
@@ -63,5 +66,6 @@ module.exports = {
   mapObjBySchema,
   emptyRes,
   getCsvArgs,
-  getMethodLimit
+  getMethodLimit,
+  checkJobAndGetUserData
 }

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -442,18 +442,30 @@ const _getBaseName = (
     isMultiExport,
     isDeposits,
     isWithdrawals,
-    isTradingPair
+    isTradingPair,
+    fileNamesMap
   }
 ) => {
-  if (!_fileNamesMap.has(queueName)) {
-    return queueName.replace(/^get/i, '').toLowerCase()
-  }
+  const isValidFileNamesMap = (
+    Array.isArray(fileNamesMap) &&
+    fileNamesMap.every(item => (
+      Array.isArray(item) &&
+      typeof item[0] === 'string' &&
+      typeof item[1] === 'string')
+    )
+  )
+  const namesMap = new Map(
+    [
+      ..._fileNamesMap,
+      ...(isValidFileNamesMap ? fileNamesMap : [])
+    ]
+  )
 
   if (
     queueName === 'getPublicTrades' &&
     !isTradingPair
   ) {
-    return _fileNamesMap.get('getPublicFunding')
+    return namesMap.get('getPublicFunding')
   }
   if (
     queueName === 'getMovements' &&
@@ -463,10 +475,13 @@ const _getBaseName = (
       ? 'deposits'
       : 'withdrawals'
   }
+  if (isMultiExport) {
+    return 'multiple-exports'
+  }
 
-  return isMultiExport
-    ? 'multiple-exports'
-    : _fileNamesMap.get(queueName)
+  return namesMap.has(queueName)
+    ? namesMap.get(queueName)
+    : _.snakeCase(queueName)
 }
 
 const _getCompleteFileName = (

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -322,7 +322,8 @@ const writeDataToStream = async (reportService, stream, jobData) => {
     const isGetActivePositionsMethod = method === 'getActivePositions'
     let { res, nextPage } = (
       isGetWalletsMethod ||
-      isGetActivePositionsMethod
+      isGetActivePositionsMethod ||
+      Object.keys({ ..._res }).every(key => key !== 'nextPage')
     )
       ? { res: _res, nextPage: null }
       : _res

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -483,7 +483,7 @@ const _getBaseName = (
 
   return namesMap.has(queueName)
     ? namesMap.get(queueName)
-    : _.snakeCase(queueName)
+    : _.snakeCase(queueName.replace(/^get/, ''))
 }
 
 const _getCompleteFileName = (

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -426,6 +426,7 @@ const _fileNamesMap = new Map([
   ['getPublicFunding', 'public_funding'],
   ['getLedgers', 'ledgers'],
   ['getOrders', 'orders'],
+  ['getActiveOrders', 'active_orders'],
   ['getMovements', 'movements'],
   ['getFundingOfferHistory', 'funding_offers_history'],
   ['getFundingLoanHistory', 'funding_loans_history'],

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { omit } = require('lodash')
 const { promisify } = require('util')
 const fs = require('fs')
 const { stringify } = require('csv')
@@ -25,28 +26,25 @@ module.exports = async job => {
     : [job.data]
 
   try {
-    if (
-      !job.data.args.params ||
-      typeof job.data.args.params !== 'object'
-    ) {
-      job.data.args.params = {}
-    }
+    job.data.args.params = { ...job.data.args.params }
 
     for (const data of jobsData) {
-      if (
-        !data.args.params ||
-        typeof data.args.params !== 'object'
-      ) {
-        data.args.params = {}
-      }
+      data.args.params = { ...data.args.params }
 
       const filePath = await createUniqueFileName(
         reportService.ctx.rootPath
       )
       filePaths.push(filePath)
+
+      const {
+        args: { params },
+        name,
+        fileNamesMap
+      } = { ...data }
       subParamsArr.push({
-        ...data.args.params,
-        name: data.name
+        ...omit(params, ['name', 'fileNamesMap']),
+        name,
+        fileNamesMap
       })
 
       const write = isUnauth

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -296,6 +296,19 @@ class ReportService extends Api {
     }
   }
 
+  async getActiveOrders (space, args, cb) {
+    try {
+      const rest = getREST(args.auth, this.ctx.grc_bfx.caller)
+
+      const _res = await rest.activeOrders()
+      const res = parseFields(_res, { executed: true })
+
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'getActiveOrders', cb)
+    }
+  }
+
   async getMovements (space, args, cb) {
     try {
       const res = await prepareApiResponse(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -218,11 +218,12 @@ class ReportService extends Api {
       const rest = getREST(args.auth, this.ctx.grc_bfx.caller)
       const end = args.params && args.params.end
 
-      const result = (end)
+      const res = (end)
         ? await rest.walletsHistory(end)
         : await rest.wallets()
 
-      cb(null, result)
+      if (!cb) return res
+      cb(null, res)
     } catch (err) {
       this._err(err, 'getWallet', cb)
     }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -22,6 +22,7 @@ const {
   getPublicTradesCsvJobData,
   getLedgersCsvJobData,
   getOrdersCsvJobData,
+  getActiveOrdersCsvJobData,
   getMovementsCsvJobData,
   getFundingOfferHistoryCsvJobData,
   getFundingLoanHistoryCsvJobData,
@@ -513,6 +514,20 @@ class ReportService extends Api {
       cb(null, status)
     } catch (err) {
       this._err(err, 'getOrdersCsv', cb)
+    }
+  }
+
+  async getActiveOrdersCsv (space, args, cb) {
+    try {
+      const status = await getCsvStoreStatus(this, args)
+      const jobData = await getActiveOrdersCsvJobData(this, args)
+      const processorQueue = this.ctx.lokue_processor.q
+
+      processorQueue.addJob(jobData)
+
+      cb(null, status)
+    } catch (err) {
+      this._err(err, 'getActiveOrdersCsv', cb)
     }
   }
 

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -724,9 +724,7 @@ class MediatorReportService extends ReportService {
   async getWallets (space, args, cb) {
     try {
       if (!await this.isSyncModeWithDbData(space, args)) {
-        super.getWallets(space, args, cb)
-
-        return
+        return super.getWallets(space, args, cb)
       }
 
       checkParams(args, 'paramsSchemaForWallets')
@@ -763,9 +761,9 @@ class MediatorReportService extends ReportService {
           date.getUTCMilliseconds() === 0
         )
       ) {
-        cb(null, wallets)
+        if (!cb) return wallets
 
-        return
+        return cb(null, wallets)
       }
 
       const ledgersArgs = {
@@ -784,9 +782,9 @@ class MediatorReportService extends ReportService {
         !Array.isArray(ledgers) ||
         ledgers.length === 0
       ) {
-        cb(null, wallets)
+        if (!cb) return wallets
 
-        return
+        return cb(null, wallets)
       }
 
       const res = wallets.map(wallet => {

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -738,15 +738,15 @@ class MediatorReportService extends ReportService {
         ? args.params.end
         : Date.now()
       const date = new Date(end)
-      const utcDate = new Date(Date.UTC(
+      const utcMts = Date.UTC(
         date.getUTCFullYear(),
         date.getUTCMonth(),
         date.getUTCDate()
-      ))
+      )
 
       const walletsArgs = {
         auth,
-        params: { end: utcDate.getTime() }
+        params: { end: utcMts }
       }
       const wallets = await this.dao.findInCollBy(
         '_getWallets',
@@ -771,7 +771,7 @@ class MediatorReportService extends ReportService {
       const ledgersArgs = {
         auth,
         params: {
-          start: utcDate.getTime() + 1,
+          start: utcMts + 1,
           end
         }
       }
@@ -821,8 +821,10 @@ class MediatorReportService extends ReportService {
         return res
       })
 
+      if (!cb) return res
       cb(null, res)
     } catch (err) {
+      if (!cb) throw err
       cb(err)
     }
   }


### PR DESCRIPTION
This PR adds the [active orders](https://docs.bitfinex.com/v2/reference#rest-auth-orders) report without sync. Base changes:
  - adds `getActiveOrders` method
  - adds `getActiveOrdersCsv` method
  - adds `typePrev` and `priceTrailing` fields to `getOrdersCsv` method
  - improves tests coverage