### PR TITLE
Hardcode sqlite3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "pug": "^2.0.3",
     "uuid": "^3.3.2",
     "winston": "^3.1.0",
-    "yargs": "^12.0.1"
+    "yargs": "^12.0.1",
+    "sqlite3": "4.0.3"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",


### PR DESCRIPTION
This PR hardcodes `sqlite3` `4.0.3` version in the `package.json`
An issue related with the following:
  - when we use `group by` and `order by` clauses together that the `sqlite3` driver `4.0.6` version returns the wrong result