### PR TITLE
Change receiving wallets logic for sync mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -729,41 +729,31 @@ class MediatorReportService extends ReportService {
 
       checkParams(args, 'paramsSchemaForWallets')
 
-      const auth = args.auth && typeof args.auth === 'object'
-        ? args.auth
-        : {}
-      const end = args.params && args.params.end
-        ? args.params.end
-        : Date.now()
+      const {
+        auth = {},
+        params: { end = Date.now() } = {}
+      } = { ...args }
 
-      const walletsArgs = {
-        auth,
-        params: { end }
-      }
       const walletsFromLedgers = await this.dao.findInCollBy(
         '_getWallets',
-        walletsArgs
+        {
+          auth,
+          params: { end }
+        }
       )
 
       const res = walletsFromLedgers
-        .filter(ledger => (
-          ledger.wallet &&
-          ledger.balance &&
-          Number.isFinite(ledger.balance)
-        )).map(({
-          wallet: type,
-          currency,
-          balance,
-          mts: mtsUpdate
-        } = {}) => ({
+        .filter(({
           type,
-          currency,
           balance,
-          unsettledInterest: null,
-          balanceAvailable: null,
-          placeHolder: null,
-          mtsUpdate
-        }))
+          currency
+        } = {}) => (
+          type &&
+          typeof type === 'string' &&
+          Number.isFinite(balance) &&
+          typeof currency === 'string' &&
+          currency.length >= 3
+        ))
 
       if (!cb) return res
       cb(null, res)

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -735,89 +735,35 @@ class MediatorReportService extends ReportService {
       const end = args.params && args.params.end
         ? args.params.end
         : Date.now()
-      const date = new Date(end)
-      const utcMts = Date.UTC(
-        date.getUTCFullYear(),
-        date.getUTCMonth(),
-        date.getUTCDate()
-      )
 
       const walletsArgs = {
         auth,
-        params: { end: utcMts }
+        params: { end }
       }
-      const wallets = await this.dao.findInCollBy(
+      const walletsFromLedgers = await this.dao.findInCollBy(
         '_getWallets',
         walletsArgs
       )
 
-      if (
-        !Array.isArray(wallets) ||
-        wallets.length === 0 ||
-        (
-          date.getUTCHours() === 0 &&
-          date.getUTCMinutes() === 0 &&
-          date.getUTCSeconds() === 0 &&
-          date.getUTCMilliseconds() === 0
-        )
-      ) {
-        if (!cb) return wallets
-
-        return cb(null, wallets)
-      }
-
-      const ledgersArgs = {
-        auth,
-        params: {
-          start: utcMts + 1,
-          end
-        }
-      }
-      const ledgers = await this.dao.findInCollBy(
-        '_getLedgers',
-        ledgersArgs
-      )
-
-      if (
-        !Array.isArray(ledgers) ||
-        ledgers.length === 0
-      ) {
-        if (!cb) return wallets
-
-        return cb(null, wallets)
-      }
-
-      const res = wallets.map(wallet => {
-        if (!Number.isFinite(wallet.balance)) {
-          return { ...wallet }
-        }
-
-        const _ledgers = ledgers.filter(ledger => {
-          return (
-            ledger.currency === wallet.currency &&
-            ledger.wallet === wallet.type
-          )
-        })
-        const res = _ledgers.reduce((accum, ledger) => {
-          const balance = Number.isFinite(ledger.amount)
-            ? accum.balance + ledger.amount
-            : accum.balance
-          const mtsUpdate = ledger.mts > accum.mtsUpdate
-            ? ledger.mts || end
-            : accum.mtsUpdate || end
-
-          return {
-            ...accum,
-            balance,
-            mtsUpdate,
-            unsettledInterest: null,
-            balanceAvailable: null,
-            placeHolder: null
-          }
-        }, { ...wallet })
-
-        return res
-      })
+      const res = walletsFromLedgers
+        .filter(ledger => (
+          ledger.wallet &&
+          ledger.balance &&
+          Number.isFinite(ledger.balance)
+        )).map(({
+          wallet: type,
+          currency,
+          balance,
+          mts: mtsUpdate
+        } = {}) => ({
+          type,
+          currency,
+          balance,
+          unsettledInterest: null,
+          balanceAvailable: null,
+          placeHolder: null,
+          mtsUpdate
+        }))
 
       if (!cb) return res
       cb(null, res)
@@ -865,10 +811,6 @@ class MediatorReportService extends ReportService {
 
   _getFundingCreditHistory (args) {
     return promisify(super.getFundingCreditHistory.bind(this))(null, args)
-  }
-
-  _getWallets (args) {
-    return promisify(super.getWallets.bind(this))(null, args)
   }
 
   async _checkAuthInApi (args) {

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -14,7 +14,6 @@ module.exports = {
   FUNDING_CREDIT_HISTORY: 'fundingCreditHistory',
   TICKERS_HISTORY: 'tickersHistory',
   POSITIONS_HISTORY: 'positionsHistory',
-  WALLETS: 'wallets',
   SYMBOLS: 'symbols',
   CURRENCIES: 'currencies'
 }

--- a/workers/loc.api/sync/dao/helpers/get-group-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-group-query.js
@@ -1,0 +1,12 @@
+'use strict'
+
+module.exports = ({
+  groupResBy = []
+} = {}) => {
+  return (
+    Array.isArray(groupResBy) &&
+    groupResBy.length > 0
+  )
+    ? `GROUP BY ${groupResBy.join(', ')}`
+    : ''
+}

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const _isInsertableArrayObjects = (type = '') => {
-  return /^((public:)|())insertable:array:objects$/i
+  return /^((hidden:)|(public:)|())insertable:array:objects$/i
     .test(type)
 }
 

--- a/workers/loc.api/sync/dao/helpers/get-sub-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-sub-query.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const getOrderQuery = require('./get-order-query')
+
+module.exports = ({
+  name,
+  subQuery: { sort = [] } = {}
+} = {}) => {
+  const _sort = getOrderQuery(sort)
+
+  if (!_sort) {
+    return name
+  }
+
+  return `(SELECT * FROM ${name} ${_sort})`
+}

--- a/workers/loc.api/sync/dao/helpers/index.js
+++ b/workers/loc.api/sync/dao/helpers/index.js
@@ -15,6 +15,8 @@ const getUniqueIndexQuery = require('./get-unique-index-query')
 const getInsertableArrayObjectsFilter = require('./get-insertable-array-objects-filter')
 const getProjectionQuery = require('./get-projection-query')
 const getPlaceholdersQuery = require('./get-placeholders-query')
+const getGroupQuery = require('./get-group-query')
+const getSubQuery = require('./get-sub-query')
 
 module.exports = {
   mixUserIdToArrData,
@@ -27,5 +29,7 @@ module.exports = {
   getUniqueIndexQuery,
   getInsertableArrayObjectsFilter,
   getProjectionQuery,
-  getPlaceholdersQuery
+  getPlaceholdersQuery,
+  getGroupQuery,
+  getSubQuery
 }

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -254,26 +254,6 @@ const _models = new Map([
     }
   ],
   [
-    ALLOWED_COLLS.WALLETS,
-    {
-      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
-      type: 'VARCHAR(255)',
-      currency: 'VARCHAR(255)',
-      balance: 'DECIMAL(22,12)',
-      unsettledInterest: 'DECIMAL(22,12)',
-      balanceAvailable: 'DECIMAL(22,12)',
-      placeHolder: 'TEXT',
-      mtsUpdate: 'BIGINT',
-      _end: 'BIGINT',
-      user_id: `INT NOT NULL,
-        CONSTRAINT wallets_fk_#{field}
-        FOREIGN KEY (#{field})
-        REFERENCES users(_id)
-        ON UPDATE CASCADE
-        ON DELETE CASCADE`
-    }
-  ],
-  [
     'publicСollsСonf',
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
@@ -492,17 +472,13 @@ const _methodCollMap = new Map([
   [
     '_getWallets',
     {
-      name: ALLOWED_COLLS.WALLETS,
-      maxLimit: null,
-      dateFieldName: 'mtsUpdate',
+      name: ALLOWED_COLLS.LEDGERS,
+      dateFieldName: 'mts',
       symbolFieldName: 'currency',
-      sort: [['mtsUpdate', -1]],
-      groupResBy: ['type', 'currency'],
-      hasNewData: false,
-      start: 0,
-      type: 'insertable:array:objects',
-      fieldsOfUniqueIndex: ['type', 'currency', 'mtsUpdate'],
-      model: { ..._models.get(ALLOWED_COLLS.WALLETS) }
+      sort: [['mts', -1], ['id', -1]],
+      groupResBy: ['wallet', 'currency'],
+      type: 'hidden:insertable:array:objects',
+      model: { ..._models.get(ALLOWED_COLLS.LEDGERS) }
     }
   ],
   [

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -475,10 +475,31 @@ const _methodCollMap = new Map([
       name: ALLOWED_COLLS.LEDGERS,
       dateFieldName: 'mts',
       symbolFieldName: 'currency',
-      sort: [['mts', -1], ['id', -1]],
+      sort: [['mts', -1]],
       groupResBy: ['wallet', 'currency'],
+      subQuery: {
+        sort: [['mts', 1], ['id', 1]]
+      },
       type: 'hidden:insertable:array:objects',
-      model: { ..._models.get(ALLOWED_COLLS.LEDGERS) }
+      model: { ..._models.get(ALLOWED_COLLS.LEDGERS) },
+      dataStructureConverter: (accum, {
+        wallet: type,
+        currency,
+        balance,
+        mts: mtsUpdate
+      } = {}) => {
+        accum.push({
+          type,
+          currency,
+          balance,
+          unsettledInterest: null,
+          balanceAvailable: null,
+          placeHolder: null,
+          mtsUpdate
+        })
+
+        return accum
+      }
     }
   ],
   [


### PR DESCRIPTION
This PR changes receiving wallets logic for the sync mode. Base changes:
  - removes wallets sync of the `api_v2`
  - changes receiving of wallets, now all data is taken from ledgers table
  - adds an ability to execute sub-query for sorting before grouping to the `findInCollBy` method of the `SqliteDAO`. This is necessary because we have rows with equal timestamp values (`mts` field) and need to sort data by `mts` and `id` fields before grouping
  - adds data structure converter to the schema for wallets from ledgers to be able to override this converter in the `bfx-reports-framework`

**Depends** on this PR [bitfinexcom/bfx-report#122](https://github.com/bitfinexcom/bfx-report/pull/122)