### PR TITLE
Fix isRateLimitError helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -13,7 +13,7 @@ const isEaiAgainError = (err) => {
 }
 
 const isRateLimitError = (err) => {
-  return /ERR(_RATE)?_LIMIT/.test(err.toString())
+  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -22,7 +22,7 @@ const translations = yaml.safeLoad(fs.readFileSync(pathToTrans, 'utf8'))
 const isElectronjsEnv = argv.isElectronjsEnv
 
 const isRateLimitError = (err) => {
-  return /ERR(_RATE)?_LIMIT/.test(err.toString())
+  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -775,6 +775,7 @@ class MediatorReportService extends ReportService {
         } = {}) => (
           type &&
           typeof type === 'string' &&
+          balance &&
           Number.isFinite(balance) &&
           typeof currency === 'string' &&
           currency.length >= 3

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -371,14 +371,16 @@ class MediatorReportService extends ReportService {
       const symbols = await this.dao.findInCollBy(
         symbolsMethod,
         args,
-        false,
-        true
+        {
+          isPublic: true
+        }
       )
       const currencies = await this.dao.findInCollBy(
         currenciesMethod,
         args,
-        false,
-        true
+        {
+          isPublic: true
+        }
       )
       const pairs = collObjToArr(symbols, field)
       const res = { pairs, currencies }
@@ -449,8 +451,10 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getTickersHistory',
         args,
-        true,
-        true
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
       )
 
       cb(null, res)
@@ -475,7 +479,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getPositionsHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -506,7 +512,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getLedgers',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -531,7 +539,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getTrades',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -556,7 +566,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingTrades',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -608,8 +620,10 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getPublicTrades',
         args,
-        true,
-        true
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
       )
 
       cb(null, res)
@@ -634,7 +648,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getOrders',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -659,7 +675,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getMovements',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -684,7 +702,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingOfferHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -709,7 +729,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingLoanHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -734,7 +756,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingCreditHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -284,9 +284,20 @@ class SqliteDAO extends DAO {
   /**
    * @override
    */
-  async findInCollBy (method, args, isPrepareResponse, isPublic) {
+  async findInCollBy (
+    method,
+    args,
+    {
+      isPrepareResponse = false,
+      isPublic = false,
+      additionalModel,
+      schema = {}
+    } = {}) {
     const user = isPublic ? null : await this.checkAuthInDb(args)
-    const methodColl = this._getMethodCollMap().get(method)
+    const methodColl = {
+      ...this._getMethodCollMap().get(method),
+      ...schema
+    }
     const params = { ...args.params }
     const {
       maxLimit,
@@ -299,6 +310,7 @@ class SqliteDAO extends DAO {
     params.limit = maxLimit
       ? getLimitNotMoreThan(params.limit, maxLimit)
       : null
+    const _model = { ...model, ...additionalModel }
 
     const exclude = ['_id']
     const filter = getInsertableArrayObjectsFilter(
@@ -323,7 +335,7 @@ class SqliteDAO extends DAO {
     const group = getGroupQuery(methodColl)
     const subQuery = getSubQuery(methodColl)
     const projection = getProjectionQuery(
-      model,
+      _model,
       exclude,
       true
     )


### PR DESCRIPTION
This PR fixed the `isRateLimitError` helper. The production `api_v2` server is responded different error message `RateLimit` for the candles endpoint:
```
    statusCode: 429
    name: StatusCodeError
    message: 429 - ["error",11010,"ratelimit: error"]
    options: {"url":"https://api.bitfinex.com/v2/candles/trade:1D:tETHUSD/hist?limit=500&start=1502323200000&end=1514332800000","method":"GET","timeout":15000,"json":true,"simple":true,"resolveWithFullResponse":false,"transform2xxOnly":false}
```