### PR TITLE
Add ability to sign reports by PGP signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "worker.js",
   "license": "Apache-2.0",
   "contributors": [
-    "Vladimir Voronkov <vsvoronkov@gmail.com>"
+    "Vladimir Voronkov <vsvoronkov@gmail.com>",
+    "Paolo Ardoino <paolo@btifinex.com>",
+    "Ezequiel Wernicke <ezequiel.wernicke@bitfinex.com>"
   ],
   "dependencies": {
     "ajv": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "bfx-report",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",
+  "contributors": [
+    "Vladimir Voronkov <vsvoronkov@gmail.com>"
+  ],
   "dependencies": {
     "ajv": "^6.5.4",
     "async": "^2.6.1",

--- a/test/1.1-report-signature.spec.js
+++ b/test/1.1-report-signature.spec.js
@@ -1,0 +1,172 @@
+'use strict'
+
+const path = require('path')
+const { assert } = require('chai')
+const request = require('supertest')
+
+const {
+  startEnviroment,
+  stopEnviroment
+} = require('./helpers/helpers.boot')
+const {
+  rmDB,
+  rmAllFiles,
+  queueToPromise
+} = require('./helpers/helpers.core')
+const {
+  createMockRESTv2SrvWithDate
+} = require('./helpers/helpers.mock-rest-v2')
+const {
+  testMethodOfGettingCsv
+} = require('./helpers/helpers.tests')
+
+const signature = `-----BEGIN PGP SIGNATURE-----
+Version: OpenPGP.js v4.5.2
+Comment: https://openpgpjs.org
+
+wl4EARYKAAYFAlzr1kMACgkQFh7gOz3Qo1Pe5QEAkpPma81YUttJNEK7zPfF
+cvJxqAW4w9Crfobqk+wvb3cA/07ej6osCli0twWcNtDw6YkWiip+IT0+SMOH
+08ODZ/ED
+=hXVs
+-----END PGP SIGNATURE-----`
+const fileHash = 'bdb9d457ab0e29806e7291bdb9d7fd17c90dad665cf437122b881cc57041899b'
+
+process.env.NODE_CONFIG_DIR = path.join(__dirname, 'config')
+const { app } = require('bfx-report-express')
+const agent = request.agent(app)
+
+let wrkReportServiceApi = null
+let auth = {
+  apiKey: 'fake',
+  apiSecret: 'fake'
+}
+let processorQueue = null
+let aggregatorQueue = null
+let mockRESTv2Srv = null
+
+const basePath = '/api'
+const tempDirPath = path.join(__dirname, '..', 'workers/loc.api/queue/temp')
+const dbDirPath = path.join(__dirname, '..', 'db')
+const date = new Date()
+const end = date.getTime()
+const start = (new Date()).setDate(date.getDate() - 90)
+const email = 'fake@email.fake'
+
+describe('Signature', () => {
+  before(async function () {
+    this.timeout(20000)
+
+    mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 10000)
+
+    await rmAllFiles(tempDirPath)
+    await rmDB(dbDirPath)
+    const env = await startEnviroment()
+
+    wrkReportServiceApi = env.wrksReportServiceApi[0]
+    processorQueue = wrkReportServiceApi.lokue_processor.q
+    aggregatorQueue = wrkReportServiceApi.lokue_aggregator.q
+  })
+
+  after(async function () {
+    this.timeout(5000)
+
+    await stopEnviroment()
+    await rmDB(dbDirPath)
+    await rmAllFiles(tempDirPath)
+
+    try {
+      await mockRESTv2Srv.close()
+    } catch (err) { }
+  })
+
+  it('it should be successfully performed by the getMultipleCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMultipleCsv',
+        isSignatureRequired: true,
+        params: {
+          email,
+          multiExport: [
+            {
+              method: 'getTradesCsv',
+              symbol: ['tBTCUSD', 'tETHUSD'],
+              end,
+              start,
+              limit: 1000,
+              timezone: 'America/Los_Angeles',
+              language: 'en'
+            },
+            {
+              method: 'getTickersHistoryCsv',
+              symbol: 'BTC',
+              end,
+              start,
+              limit: 1000,
+              language: 'ru'
+            }
+          ]
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the getLedgersCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLedgersCsv',
+        params: {
+          symbol: ['BTC'],
+          end,
+          start,
+          limit: 1000,
+          timezone: -3,
+          email,
+          isSignatureRequired: true
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the verifyDigitalSignature method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'verifyDigitalSignature',
+        signature,
+        fileHash,
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isOk(res)
+  })
+})

--- a/test/1.1-report-signature.spec.js
+++ b/test/1.1-report-signature.spec.js
@@ -167,4 +167,17 @@ describe('Signature', () => {
 
     assert.isOk(res)
   })
+
+  it('it should be successfully performed by the /verify-digital-signature route', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/verify-digital-signature`)
+      .attach('file', Buffer.from('some report', 'utf8'), 'some-report.json')
+      .field({ signature })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isOk(res)
+  })
 })

--- a/test/1.1-report-signature.spec.js
+++ b/test/1.1-report-signature.spec.js
@@ -101,16 +101,14 @@ describe('Signature', () => {
               end,
               start,
               limit: 1000,
-              timezone: 'America/Los_Angeles',
-              language: 'en'
+              timezone: 'America/Los_Angeles'
             },
             {
               method: 'getTickersHistoryCsv',
               symbol: 'BTC',
               end,
               start,
-              limit: 1000,
-              language: 'ru'
+              limit: 1000
             }
           ]
         },

--- a/test/1.1-report-signature.spec.js
+++ b/test/1.1-report-signature.spec.js
@@ -91,9 +91,9 @@ describe('Signature', () => {
       .send({
         auth,
         method: 'getMultipleCsv',
-        isSignatureRequired: true,
         params: {
           email,
+          isSignatureRequired: true,
           multiExport: [
             {
               method: 'getTradesCsv',

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -84,6 +84,7 @@ describe('Queue', () => {
         method: 'getMultipleCsv',
         params: {
           email,
+          language: 'ru',
           multiExport: [
             {
               method: 'getTradesCsv',
@@ -91,16 +92,14 @@ describe('Queue', () => {
               end,
               start,
               limit: 1000,
-              timezone: 'America/Los_Angeles',
-              language: 'en'
+              timezone: 'America/Los_Angeles'
             },
             {
               method: 'getTickersHistoryCsv',
               symbol: 'BTC',
               end,
               start,
-              limit: 1000,
-              language: 'ru'
+              limit: 1000
             }
           ]
         },

--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -14,7 +14,10 @@ const testProcQueue = (procRes) => {
     'subParamsArr',
     'isUnauth'
   ])
-  assert.isString(procRes.userInfo)
+  assert.isObject(procRes.userInfo)
+  assert.isString(procRes.userInfo.username)
+  assert.isString(procRes.userInfo.email)
+  assert.isNumber(procRes.userInfo.userId)
   assert.isString(procRes.name)
   assert.isString(procRes.email)
   assert.isArray(procRes.filePaths)

--- a/test/helpers/helpers.worker.js
+++ b/test/helpers/helpers.worker.js
@@ -15,6 +15,7 @@ const startHelpers = (
   workers = [
     { name: 's3', port: 13371 },
     { name: 'sendgrid', port: 1310 },
+    { name: 'gpg', port: 1320 },
     { name: 'testcalls', port: 1300 }
   ]
 ) => {

--- a/test/simulate/mocks-spies/gpg.js
+++ b/test/simulate/mocks-spies/gpg.js
@@ -55,7 +55,7 @@ function addFunctions (ExtApi) {
     } = args
 
     if (!signature) return cb(new Error('ERR_API_NO_SIGNATURE'))
-    if (!fileHash) return cb(new Error('ERR_API_NO_FILE_HASH'))
+    if (!file && !fileHash) return cb(new Error('ERR_API_NO_FILE_HASH_AND_FILE'))
 
     const grcBfx = this.ctx.grc_bfx
     const call = {

--- a/test/simulate/mocks-spies/gpg.js
+++ b/test/simulate/mocks-spies/gpg.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const workerArgs = ['rest:ext:gpg']
+
+function addFunctions (ExtApi) {
+  ExtApi.prototype.getDigitalSignature = function (space, file, args, cb) {
+    const signature = `-----BEGIN PGP SIGNATURE-----
+    Version: OpenPGP.js v4.5.2
+    Comment: https://openpgpjs.org
+    
+    wl4EARYKAAYFAlzr1kMACgkQFh7gOz3Qo1Pe5QEAkpPma81YUttJNEK7zPfF
+    cvJxqAW4w9Crfobqk+wvb3cA/07ej6osCli0twWcNtDw6YkWiip+IT0+SMOH
+    08ODZ/ED
+    =hXVs
+    -----END PGP SIGNATURE-----`
+
+    const {
+      userId,
+      username,
+      email
+    } = args
+
+    if (!file) return cb(new Error('ERR_API_NO_FILE'))
+    if (!userId) return cb(new Error('ERR_API_NO_USER_ID'))
+    if (!username) return cb(new Error('ERR_API_NO_USERNAME'))
+    if (!email) return cb(new Error('ERR_API_NO_EMAIL'))
+
+    const grcBfx = this.ctx.grc_bfx
+    const call = {
+      worker: 'ext.gpg',
+      on: 'getDigitalSignature',
+      params: { file, args },
+      res: { signature },
+      timestamp: Date.now()
+    }
+
+    grcBfx.req(
+      'rest:ext:testcalls',
+      'addCall',
+      [call],
+      { timeout: 10000 },
+      (err, data) => {
+        if (err) cb(new Error('ext.gpg:getDigitalSignature:testcalls'))
+        else return cb(null, signature)
+      }
+    )
+  }
+
+  ExtApi.prototype.verifyDigitalSignature = function (space, file, args, cb) {
+    const isValid = true
+
+    const {
+      signature,
+      fileHash
+    } = args
+
+    if (!signature) return cb(new Error('ERR_API_NO_SIGNATURE'))
+    if (!fileHash) return cb(new Error('ERR_API_NO_FILE_HASH'))
+
+    const grcBfx = this.ctx.grc_bfx
+    const call = {
+      worker: 'ext.gpg',
+      on: 'verifyDigitalSignature',
+      params: { file, args },
+      res: { isValid },
+      timestamp: Date.now()
+    }
+
+    grcBfx.req(
+      'rest:ext:testcalls',
+      'addCall',
+      [call],
+      { timeout: 10000 },
+      (err, data) => {
+        if (err) cb(new Error('ext.gpg:verifyDigitalSignature:testcalls'))
+        else return cb(null, isValid)
+      }
+    )
+  }
+}
+
+module.exports = {
+  addFunctions,
+  workerArgs
+}

--- a/workers/api.service.report.wrk.js
+++ b/workers/api.service.report.wrk.js
@@ -266,6 +266,12 @@ class WrkReportServiceApi extends WrkApi {
         isUnauth: true
       })
     })
+    processorQueue.on('error:base', (err) => {
+      this.logger.error(`PROCESSOR:QUEUE: ${err.stack || err}`)
+    })
+    aggregatorQueue.on('error:base', (err) => {
+      this.logger.error(`AGGREGATOR:QUEUE: ${err.stack || err}`)
+    })
   }
 
   _start (cb) {

--- a/workers/loc.api/helpers/check-job-and-get-user-data.js
+++ b/workers/loc.api/helpers/check-job-and-get-user-data.js
@@ -13,9 +13,23 @@ module.exports = async (
   const userId = Number.isInteger(uId)
     ? uId
     : await hasJobInQueueWithStatusBy(reportService, args)
-  const userInfo = uInfo && typeof uInfo === 'string'
+
+  const {
+    username,
+    email,
+    id
+  } = { ...uInfo }
+  const _userInfo = (
+    username && typeof username === 'string' &&
+    email && typeof email === 'string' &&
+    Number.isInteger(id)
+  )
     ? uInfo
-    : await reportService._getUsername(args)
+    : await reportService._getUserInfo(args)
+  const userInfo = {
+    ..._userInfo,
+    userId: _userInfo.id
+  }
 
   return {
     userId,

--- a/workers/loc.api/helpers/grc-bfx-req.js
+++ b/workers/loc.api/helpers/grc-bfx-req.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = (
+  rService,
+  {
+    service,
+    action,
+    args = [],
+    timeout = 10000
+  } = {}
+) => {
+  return new Promise((resolve, reject) => {
+    rService.ctx.grc_bfx.req(
+      service,
+      action,
+      args,
+      { timeout },
+      (err, data) => {
+        if (err) {
+          reject(err)
+
+          return
+        }
+
+        resolve(data)
+      }
+    )
+  })
+}

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -40,6 +40,7 @@ const {
 const checkJobAndGetUserData = require(
   './check-job-and-get-user-data'
 )
+const grcBfxReq = require('./grc-bfx-req')
 
 module.exports = {
   getREST,
@@ -67,5 +68,6 @@ module.exports = {
   emptyRes,
   getCsvArgs,
   getMethodLimit,
-  checkJobAndGetUserData
+  checkJobAndGetUserData,
+  grcBfxReq
 }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -169,6 +169,7 @@ const paramsSchemaForMultipleCsv = {
     email: {
       type: 'string'
     },
+    language,
     multiExport: {
       type: 'array',
       minItems: 1,

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -23,6 +23,7 @@ module.exports = async job => {
       name,
       filePaths,
       subParamsArr,
+      isSignatureRequired,
       email,
       isUnauth,
       s3Conf,
@@ -41,6 +42,7 @@ module.exports = async job => {
         filePaths,
         name,
         subParamsArr,
+        isSignatureRequired,
         {
           ...userInfo,
           email

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -27,7 +27,8 @@ module.exports = async job => {
       email,
       isUnauth,
       s3Conf,
-      emailConf
+      emailConf,
+      language
     } = job.data
 
     const isEnableToSendEmail = (
@@ -57,7 +58,7 @@ module.exports = async job => {
         s3Data.map((item, i) => ({
           ...item,
           isUnauth,
-          language: subParamsArr[i].language
+          language
         }))
       )
 

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -20,6 +20,7 @@ module.exports = async job => {
   try {
     const {
       userInfo,
+      userId,
       name,
       filePaths,
       subParamsArr,
@@ -41,7 +42,11 @@ module.exports = async job => {
         filePaths,
         name,
         subParamsArr,
-        userInfo
+        {
+          userId,
+          name: userInfo,
+          email
+        }
       )
 
       await sendMail(

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -20,7 +20,6 @@ module.exports = async job => {
   try {
     const {
       userInfo,
-      userId,
       name,
       filePaths,
       subParamsArr,
@@ -43,8 +42,7 @@ module.exports = async job => {
         name,
         subParamsArr,
         {
-          userId,
-          name: userInfo,
+          ...userInfo,
           email
         }
       )
@@ -73,7 +71,7 @@ module.exports = async job => {
           filePath,
           subParamsArr[count].name || name,
           { ...subParamsArr[count] },
-          userInfo
+          userInfo.username
         )
 
         count += 1

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -303,7 +303,7 @@ const writeDataToStream = async (reportService, stream, jobData) => {
     throw new Error('ERR_METHOD_NOT_FOUND')
   }
 
-  const queue = reportService.ctx.lokue_aggregator.q
+  const queue = reportService.ctx.lokue_processor.q
   const propName = jobData.propNameForPagination
   const formatSettings = jobData.formatSettings
 
@@ -641,7 +641,7 @@ const uploadS3 = async (
   const fileNameWithoutExt = _getCompleteFileName(
     subParamsArr[0].name,
     subParamsArr[0],
-    userInfo.name,
+    userInfo.username,
     false,
     isMultiExport
   )
@@ -653,7 +653,7 @@ const uploadS3 = async (
         name: _getCompleteFileName(
           subParamsArr[i].name,
           subParamsArr[i],
-          userInfo.name
+          userInfo.username
         )
       }
     }

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -625,6 +625,7 @@ const uploadS3 = async (
   filePaths,
   queueName,
   subParamsArr,
+  isSignatureRequired,
   userInfo
 ) => {
   const grcBfx = rService.ctx.grc_bfx
@@ -667,7 +668,7 @@ const uploadS3 = async (
   ))
 
   const promises = buffers.map(async (buffer, i) => {
-    const isSignatureRequired = subParamsArr[i].isSignatureRequired && !syncMode
+    const isSignReq = isSignatureRequired && !syncMode
     const fileName = isСompress && isMultiExport
       ? `${fileNameWithoutExt}.zip`
       : `${streams[i].data.name.slice(0, -3)}${isСompress ? 'zip' : 'csv'}`
@@ -678,7 +679,7 @@ const uploadS3 = async (
     }
     const hexStrBuff = buffer.toString('hex')
 
-    const signature = isSignatureRequired
+    const signature = isSignReq
       ? await rService._grcBfxReq({
         service: 'rest:ext:gpg',
         action: 'getDigitalSignature',
@@ -691,7 +692,7 @@ const uploadS3 = async (
       args: [hexStrBuff, opts]
     })
 
-    if (isSignatureRequired) {
+    if (isSignReq) {
       const signatureS3 = await _uploadSignToS3(
         rService,
         configs,

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -28,6 +28,18 @@ module.exports = async job => {
   try {
     job.data.args.params = { ...job.data.args.params }
 
+    const {
+      userInfo,
+      userId,
+      name,
+      args: {
+        params: {
+          email,
+          isSignatureRequired
+        }
+      }
+    } = { ...job.data }
+
     for (const data of jobsData) {
       data.args.params = { ...data.args.params }
 
@@ -73,12 +85,13 @@ module.exports = async job => {
 
     job.done()
     processorQueue.emit('completed', {
-      userInfo: job.data.userInfo,
-      userId: job.data.userId,
-      name: job.data.name,
+      userInfo,
+      userId,
+      name,
       filePaths,
       subParamsArr,
-      email: job.data.args.params.email,
+      email,
+      isSignatureRequired,
       isUnauth
     })
   } catch (err) {

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -35,7 +35,8 @@ module.exports = async job => {
       args: {
         params: {
           email,
-          isSignatureRequired
+          isSignatureRequired,
+          language
         }
       }
     } = { ...job.data }
@@ -92,6 +93,7 @@ module.exports = async job => {
       subParamsArr,
       email,
       isSignatureRequired,
+      language,
       isUnauth
     })
   } catch (err) {

--- a/workers/loc.api/queue/translations/email.yml
+++ b/workers/loc.api/queue/translations/email.yml
@@ -8,7 +8,9 @@ en:
     ifDidNotInitAction: If you did not initiate this action and you suspect that your account may be compromised, please
     freezeAccount: freeze your account
     contactSupport: and contact support
-    pgpSignature: PGP digital signature file
+    youCan: You can
+    download: download
+    pgpSignature: a PGP digital signature file
 
 ru:
   template:
@@ -20,7 +22,9 @@ ru:
     ifDidNotInitAction: Если вы не инициировали это действие и подозреваете, что ваша учетная запись может быть взломана, пожалуйста,
     freezeAccount: заблокируйте ее
     contactSupport: и обратитесь в службу поддержки
-    pgpSignature: Файл цифровой подписи PGP
+    youCan: Вы можете
+    download: скачать
+    pgpSignature: файл цифровой подписи PGP
 
 zh-CN:
   template:

--- a/workers/loc.api/queue/translations/email.yml
+++ b/workers/loc.api/queue/translations/email.yml
@@ -8,6 +8,7 @@ en:
     ifDidNotInitAction: If you did not initiate this action and you suspect that your account may be compromised, please
     freezeAccount: freeze your account
     contactSupport: and contact support
+    pgpSignature: PGP digital signature file
 
 ru:
   template:
@@ -19,6 +20,7 @@ ru:
     ifDidNotInitAction: Если вы не инициировали это действие и подозреваете, что ваша учетная запись может быть взломана, пожалуйста,
     freezeAccount: заблокируйте ее
     contactSupport: и обратитесь в службу поддержки
+    pgpSignature: Файл цифровой подписи PGP
 
 zh-CN:
   template:

--- a/workers/loc.api/queue/views/email.pug
+++ b/workers/loc.api/queue/views/email.pug
@@ -14,11 +14,20 @@ else
       | #{fileName}
   if signatureS3
     p(style='color: #606060;font-size: 15px;line-height: 150%;')
+      :translate(prop='template.youCan')
+        You can
+      a(
+        style=`
+          margin:0 5px;letter-spacing:.7;line-height:100%;
+          text-decoration:none;color:#4995c4;word-wrap:break-word;
+        `
+        target='_blank'
+        href=signatureS3.presigned_url
+      )
+        :translate(prop='template.download')
+          download
       :translate(prop='template.pgpSignature')
         PGP digital signature file
-      | :
-      a(style='margin-left: 5px;' target='_blank' href=signatureS3.presigned_url)
-        | link
 
   p(style='color: #606060;font-size: 15px;line-height: 150%;')
     :translate(prop='template.ifDidNotInitAction')

--- a/workers/loc.api/queue/views/email.pug
+++ b/workers/loc.api/queue/views/email.pug
@@ -12,6 +12,13 @@ else
     | :
     b(style='margin-left: 5px;')
       | #{fileName}
+  if signatureS3
+    p(style='color: #606060;font-size: 15px;line-height: 150%;')
+      :translate(prop='template.pgpSignature')
+        PGP digital signature file
+      | :
+      a(style='margin-left: 5px;' target='_blank' href=signatureS3.presigned_url)
+        | link
 
   p(style='color: #606060;font-size: 15px;line-height: 150%;')
     :translate(prop='template.ifDidNotInitAction')

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -74,20 +74,6 @@ class ReportService extends Api {
     return rest.userInfo()
   }
 
-  async _getUsername (args) {
-    try {
-      const { username } = await this._getUserInfo(args)
-
-      if (!username || typeof username !== 'string') {
-        return false
-      }
-
-      return username
-    } catch (err) {
-      return false
-    }
-  }
-
   async getEmail (space, args, cb) {
     try {
       const result = await this._getUserInfo(args)

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -10,7 +10,8 @@ const {
   parseFields,
   accountCache,
   getTimezoneConf,
-  prepareApiResponse
+  prepareApiResponse,
+  grcBfxReq
 } = require('./helpers')
 const {
   getTradesCsvJobData,
@@ -36,6 +37,25 @@ class ReportService extends Api {
   space (service, msg) {
     const space = super.space(service, msg)
     return space
+  }
+
+  _grcBfxReq (query = {}) {
+    return grcBfxReq(this, query)
+  }
+
+  async verifyDigitalSignature (space, args, cb) {
+    try {
+      const res = await this._grcBfxReq({
+        service: 'rest:ext:gpg',
+        action: 'verifyDigitalSignature',
+        args: [null, args]
+      })
+
+      if (!cb) return res
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'verifyDigitalSignature', cb)
+    }
   }
 
   isSyncModeConfig (space, args, cb = () => { }) {

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -37,7 +37,8 @@ class MediatorReportService extends ReportService {
     try {
       let userInfo = {
         email: null,
-        timezone: null
+        timezone: null,
+        id: null
       }
 
       try {
@@ -863,8 +864,9 @@ class MediatorReportService extends ReportService {
     const {
       email,
       timezone,
-      username
-    } = await this._getUserInfo(args)
+      username,
+      id
+    } = await super._getUserInfo(args)
 
     if (!email) {
       throw new AuthError()
@@ -873,22 +875,33 @@ class MediatorReportService extends ReportService {
     return {
       email,
       timezone,
-      username
+      username,
+      id
     }
   }
 
   /**
    * @override
    */
-  async _getUsername (args) {
+  async _getUserInfo (args) {
     try {
-      const { username } = await this.dao.checkAuthInDb(args)
+      const {
+        username,
+        timezone,
+        email,
+        id
+      } = await this.dao.checkAuthInDb(args)
 
       if (!username || typeof username !== 'string') {
         return false
       }
 
-      return username
+      return {
+        username,
+        timezone,
+        email,
+        id
+      }
     } catch (err) {
       return false
     }

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -453,7 +453,8 @@ class SqliteDAO extends DAO {
               'apiSecret',
               'email',
               'timezone',
-              'username'
+              'username',
+              'id'
             ]
           ),
           active: 1,
@@ -468,7 +469,7 @@ class SqliteDAO extends DAO {
       user,
       newData,
       data,
-      ['email', 'timezone', 'username']
+      ['email', 'timezone', 'username', 'id']
     )
 
     const res = await this.updateCollBy(

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -9,6 +9,7 @@ const _models = new Map([
     'users',
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      id: 'BIGINT',
       email: 'VARCHAR(255)',
       apiKey: 'VARCHAR(255)',
       apiSecret: 'VARCHAR(255)',


### PR DESCRIPTION
This PR adds an ability to sign reports by PGP signature. Basic changes:
  - adds `verifyDigitalSignature` method
  - implements reports signing by PGP signature before reports uploading to `S3` using this service [bfx-ext-sendgrid-js](https://github.com/bitfinexcom/bfx-ext-gpg-js)
  - improves email template
  -  adds corresponding test coverage

**Depends** on this PR [bitfinexcom/bfx-ext-gpg-js#1](https://github.com/bitfinexcom/bfx-ext-gpg-js/pull/1)

**TODO**: need to add zh-CN and zh-TW translations