### PR TITLE
Add support for futures to sync mode

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -205,7 +205,7 @@ describe('API', () => {
     assert.isObject(res.body.result)
     assert.isArray(res.body.result.pairs)
     assert.isArray(res.body.result.currencies)
-    assert.lengthOf(res.body.result.pairs, 11)
+    assert.lengthOf(res.body.result.pairs, 13)
     assert.lengthOf(res.body.result.currencies, 11)
 
     res.body.result.pairs.forEach(item => {

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -693,7 +693,7 @@ describe('Sync mode with SQLite', () => {
     assert.isObject(res.body.result)
     assert.isArray(res.body.result.pairs)
     assert.isArray(res.body.result.currencies)
-    assert.lengthOf(res.body.result.pairs, 11)
+    assert.lengthOf(res.body.result.pairs, 13)
     assert.lengthOf(res.body.result.currencies, 11)
 
     res.body.result.pairs.forEach(item => {

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -147,6 +147,7 @@ const getMockDataOpts = () => ({
   f_credit_hist: { limit: 500 },
   user_info: null,
   symbols: null,
+  futures: null,
   currencies: null
 })
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -20,6 +20,13 @@ module.exports = new Map([
     ]]
   ],
   [
+    'futures',
+    [[
+      'BTCF0:USDF0',
+      'BTCF0:USTF0'
+    ]]
+  ],
+  [
     'user_info',
     [
       123,

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -366,23 +366,32 @@ class MediatorReportService extends ReportService {
       checkParams(args, 'paramsSchemaForApi')
 
       const symbolsMethod = '_getSymbols'
+      const futuresMethod = '_getFutures'
       const currenciesMethod = '_getCurrencies'
-      const { field } = getMethodCollMap().get(symbolsMethod)
+      const {
+        field: symbolsField
+      } = getMethodCollMap().get(symbolsMethod)
+      const {
+        field: futuresField
+      } = getMethodCollMap().get(futuresMethod)
       const symbols = await this.dao.findInCollBy(
         symbolsMethod,
         args,
-        {
-          isPublic: true
-        }
+        { isPublic: true }
+      )
+      const futures = await this.dao.findInCollBy(
+        futuresMethod,
+        args,
+        { isPublic: true }
       )
       const currencies = await this.dao.findInCollBy(
         currenciesMethod,
         args,
-        {
-          isPublic: true
-        }
+        { isPublic: true }
       )
-      const pairs = collObjToArr(symbols, field)
+      const symbolsArr = collObjToArr(symbols, symbolsField)
+      const futuresArr = collObjToArr(futures, futuresField)
+      const pairs = [...symbolsArr, ...futuresArr]
       const res = { pairs, currencies }
 
       cb(null, res)

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -16,5 +16,6 @@ module.exports = {
   TICKERS_HISTORY: 'tickersHistory',
   POSITIONS_HISTORY: 'positionsHistory',
   SYMBOLS: 'symbols',
+  FUTURES: 'futures',
   CURRENCIES: 'currencies'
 }

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -296,6 +296,13 @@ const _models = new Map([
     }
   ],
   [
+    ALLOWED_COLLS.FUTURES,
+    {
+      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      pairs: 'VARCHAR(255)'
+    }
+  ],
+  [
     ALLOWED_COLLS.CURRENCIES,
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
@@ -547,6 +554,18 @@ const _methodCollMap = new Map([
       hasNewData: true,
       type: 'public:updatable:array',
       model: { ..._models.get(ALLOWED_COLLS.SYMBOLS) }
+    }
+  ],
+  [
+    '_getFutures',
+    {
+      name: ALLOWED_COLLS.FUTURES,
+      maxLimit: 5000,
+      field: 'pairs',
+      sort: [['pairs', 1]],
+      hasNewData: true,
+      type: 'public:updatable:array',
+      model: { ..._models.get(ALLOWED_COLLS.FUTURES) }
     }
   ],
   [


### PR DESCRIPTION
This PR adds support for futures to sync mode. Basic changes:
  - adds support for futures to sync mode
  - adds futures mock data
  - change tests to support futures

**Depends** on this PR [bitfinexcom/bfx-api-mock-srv#18](https://github.com/bitfinexcom/bfx-api-mock-srv/pull/18)