### PR TITLE
Add minor changes for adding account snapshot report

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bfx-wrk-api": "git+https://github.com/bitfinexcom/bfx-wrk-api.git",
     "bitfinex-api-node": "^2.0.6",
     "colors": "^1.3.0",
-    "csv": "^3.1.0",
+    "csv": "^5.1.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.10",
     "lru": "^3.1.0",

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -502,7 +502,8 @@ const _getCompleteFileName = (
 ) => {
   const {
     start,
-    end
+    end,
+    isOnMomentInName
   } = params
   const baseName = _getBaseName(
     queueName,
@@ -523,7 +524,11 @@ const _getCompleteFileName = (
     : formattedDateNow
   const _ext = ext ? `.${ext}` : ''
   const _userInfo = userInfo ? `${userInfo}_` : ''
-  const fileName = queueName === 'getWallets' || isMultiExport
+  const fileName = (
+    queueName === 'getWallets' ||
+    isMultiExport ||
+    isOnMomentInName
+  )
     ? `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${_ext}`
     : `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${_ext}`
 

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -201,7 +201,7 @@ const _dataNormalizer = (obj, method, params) => {
   return res
 }
 
-const _write = (res, stream, formatSettings, method, params) => {
+const write = (res, stream, formatSettings, params, method) => {
   res.forEach((item) => {
     const _item = _dataNormalizer(item, method, params)
     const res = _dataFormatter(_item, formatSettings, params)
@@ -241,7 +241,7 @@ const _filterMovementsByAmount = (res, args) => {
   return res
 }
 
-const _getDataFromApi = async (getData, args) => {
+const getDataFromApi = async (getData, args) => {
   let countRateLimitError = 0
   let countNonceSmallError = 0
   let res = null
@@ -319,7 +319,7 @@ const writeDataToStream = async (reportService, stream, jobData) => {
   while (true) {
     queue.emit('progress', 0)
 
-    const _res = await _getDataFromApi(
+    const _res = await getDataFromApi(
       getData,
       currIterationArgs
     )
@@ -390,12 +390,12 @@ const writeDataToStream = async (reportService, stream, jobData) => {
       isAllData = true
     }
 
-    _write(
+    write(
       res,
       stream,
       formatSettings,
-      method,
-      { ..._args.params }
+      { ..._args.params },
+      method
     )
 
     count += res.length
@@ -422,7 +422,7 @@ const _writeMessageToStream = (reportService, stream, message) => {
   const queue = reportService.ctx.lokue_aggregator.q
 
   queue.emit('progress', 0)
-  _write([message], stream)
+  write([message], stream)
   queue.emit('progress', 100)
 }
 
@@ -773,5 +773,7 @@ module.exports = {
   uploadS3,
   sendMail,
   moveFileToLocalStorage,
-  hasS3AndSendgrid
+  hasS3AndSendgrid,
+  write,
+  getDataFromApi
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -217,6 +217,7 @@ class ReportService extends Api {
         'symbol'
       )
 
+      if (!cb) return res
       cb(null, res)
     } catch (err) {
       this._err(err, 'getPositionsAudit', cb)

--- a/workers/loc.api/sync/dao/helpers/get-where-query.js
+++ b/workers/loc.api/sync/dao/helpers/get-where-query.js
@@ -8,7 +8,9 @@ const _getCompareOperator = (
   origFieldName,
   isArr,
   gtKeys,
+  gteKeys,
   ltKeys,
+  lteKeys,
   isNot
 ) => {
   if (origFieldName === 'start') {
@@ -24,10 +26,22 @@ const _getCompareOperator = (
     return '>'
   }
   if (
+    Array.isArray(gteKeys) &&
+    gteKeys.some(key => key === origFieldName)
+  ) {
+    return '>='
+  }
+  if (
     Array.isArray(ltKeys) &&
     ltKeys.some(key => key === origFieldName)
   ) {
     return '<'
+  }
+  if (
+    Array.isArray(lteKeys) &&
+    lteKeys.some(key => key === origFieldName)
+  ) {
+    return '<='
   }
   if (isArr) {
     return isNot ? 'NOT IN' : 'IN'
@@ -104,13 +118,21 @@ module.exports = (filter = {}, isNotSetWhereClause) => {
   const ltObj = filterObj.$lt && typeof filterObj.$lt === 'object'
     ? filterObj.$lt
     : {}
+  const gteObj = filterObj.$gte && typeof filterObj.$gte === 'object'
+    ? filterObj.$gte
+    : {}
+  const lteObj = filterObj.$lte && typeof filterObj.$lte === 'object'
+    ? filterObj.$lte
+    : {}
   const notObj = filterObj.$not && typeof filterObj.$not === 'object'
     ? filterObj.$not
     : {}
   const _filter = {
-    ...omit(filterObj, ['$gt', '$lt', '$not']),
+    ...omit(filterObj, ['$gt', '$gte', '$lt', '$lte', '$not']),
     ...gtObj,
+    ...gteObj,
     ...ltObj,
+    ...lteObj,
     ...notObj
   }
   const keys = Object.keys(omit(_filter, ['_dateFieldName']))
@@ -131,7 +153,9 @@ module.exports = (filter = {}, isNotSetWhereClause) => {
         curr,
         isArr,
         Object.keys(gtObj),
+        Object.keys(gteObj),
         Object.keys(ltObj),
+        Object.keys(lteObj),
         Object.keys(notObj).length > 0
       )
 


### PR DESCRIPTION
This PR adds minor changes for adding a account snapshot report to the [bfx-reports-frameworks](https://github.com/bitfinexcom/bfx-reports-framework). Basic changes:
  - adds `gte` and `lte` clauses to the `DAO`
  - adds async handling to the `getPositionsAudit` method
  - adds `csvCustomWriter` to the `processor` queue
  - bumps csv module version to `5.1.1`
  - adds to exports `write` and `getDataFromApi` modules in queue helpers module
  - adds an ability to pass a flag for generating of a file name with `current moment` timestamp