### PR TITLE
Change symbols formatting for csv generating

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "async": "^3.1.0",
     "better-npm-run": "^0.1.0",
     "bfx-facs-deflate": "git+https://github.com:bitfinexcom/bfx-facs-deflate.git",
+    "bfx-facs-interval": "git+https://github.com/bitfinexcom/bfx-facs-interval.git",
     "bfx-facs-lokue": "git+https://github.com:bitfinexcom/bfx-facs-lokue.git",
     "bfx-svc-boot-js": "https://github.com/bitfinexcom/bfx-svc-boot-js.git",
     "bfx-wrk-api": "git+https://github.com/bitfinexcom/bfx-wrk-api.git",

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -44,10 +44,29 @@ const _formatters = {
   },
   symbol: symbol => {
     if (
+      symbol.length > 6 &&
+      /.+[:].+/.test(symbol)
+    ) {
+      const str = (
+        symbol[0] === 't' ||
+        symbol[0] === 'f'
+      )
+        ? symbol.slice(1)
+        : symbol
+
+      return str.split(':').join('/')
+    }
+    if (
       symbol[0] !== 't' &&
       symbol[0] !== 'f'
     ) {
       return symbol
+    }
+    if (
+      symbol.length > 4 &&
+      symbol.length < 7
+    ) {
+      return symbol.slice(1)
     }
 
     return `${symbol.slice(1, 4)}${symbol[4]


### PR DESCRIPTION
This PR changes symbols formatting for csv generating
This cover these situations:
  - `BTCF0:USTF0` => `BTCF0/USTF0`
  - `tBTCF0:USTF0` => `BTCF0/USTF0`
  - `tBTCF0` => `BTCF0`
  - `BTCF0` => `BTCF0`
  - `tBTCUSD` => `BTC/USD`
  - `BTCUSD` => `BTCUSD`
  - `tBTC` => `BTC`
  - `BTC` => `BTC`