### PR TITLE
Improve max limit handling for movements

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1290,7 +1290,7 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
-  it('it should not be successfully performed by the getMovements method, a greater limit is needed', async function () {
+  it('it should not be successfully performed by the getLedgers method, a greater limit is needed', async function () {
     this.timeout(5000)
 
     await mockRESTv2Srv.close()
@@ -1301,7 +1301,7 @@ describe('API', () => {
       .type('json')
       .send({
         auth,
-        method: 'getMovements',
+        method: 'getLedgers',
         params: {
           symbol: 'BTC',
           start: 0,
@@ -1318,5 +1318,51 @@ describe('API', () => {
     assert.propertyVal(res.body.error, 'code', 400)
     assert.propertyVal(res.body.error, 'message', 'A greater limit is needed as to show the data correctly')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getMovements method, without MinLimitParamError error', async function () {
+    this.timeout(5000)
+
+    await mockRESTv2Srv.close()
+    mockRESTv2Srv = createMockRESTv2SrvWithAllData()
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMovements',
+        params: {
+          symbol: 'BTC',
+          start: 0,
+          end,
+          limit: 25
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'currency',
+      'currencyName',
+      'mtsStarted',
+      'mtsUpdated',
+      'status',
+      'amount',
+      'fees',
+      'destinationAddress',
+      'transactionId'
+    ])
   })
 })

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -207,7 +207,6 @@ const _isNotContainedSameMts = (
   const mts = firstElem[datePropName]
 
   return (
-    methodApi !== 'movements' ||
     getMethodLimit('max', methodApi) !== limit ||
     apiRes.some((item) => {
       const _item = { ...item }


### PR DESCRIPTION
This PR improves max limit handling for movements. If limit sent is === to MAX LIMIT, instead of returning a response that the limit should be bigger, will return the response anyway