### PR TITLE
Fix issue on many responses with same mts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -83,6 +83,12 @@
         "NODE_ENV": "test"
       }
     },
+    "unit": {
+      "command": "mocha './workers/**/__test__/*.spec.js' --config .mocharc.json",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
     "testDev": {
       "command": "standard && mocha --recursive test/**/*-dev.spec.js --exit --timeout 10000",
       "env": {
@@ -96,6 +102,7 @@
     "startServDev": "better-npm-run start:serv",
     "startSimulEnv": "node test/simulate/simulate-enviroment.js",
     "test": "better-npm-run test",
-    "testDev": "better-npm-run testDev"
+    "testDev": "better-npm-run testDev",
+    "unit": "better-npm-run unit"
   }
 }

--- a/workers/loc.api/helpers/__test__/filter-response.spec.js
+++ b/workers/loc.api/helpers/__test__/filter-response.spec.js
@@ -191,6 +191,34 @@ describe('filterResponse helper', () => {
     })
   })
 
+  it('it should be successful with $like condition, not consider capital letters', function () {
+    this.timeout(1000)
+
+    const resArr = [
+      filterResponse(
+        mockData,
+        { $like: { description: 'settlement%' } }
+      ),
+      filterResponse(
+        mockData,
+        { $like: { description: 'SETTLEMENT%' } }
+      ),
+      filterResponse(
+        mockData,
+        { $like: { description: 'settleMent%' } }
+      )
+    ]
+
+    resArr.forEach((res) => {
+      assert.isAbove(res.length, 0)
+
+      res.forEach(({ description }) => {
+        assert.isString(description)
+        assert.match(description, /^settlement/i)
+      })
+    })
+  })
+
   it('it should be successful with $like condition using escaping <%>', function () {
     this.timeout(1000)
 

--- a/workers/loc.api/helpers/__test__/filter-response.spec.js
+++ b/workers/loc.api/helpers/__test__/filter-response.spec.js
@@ -443,4 +443,40 @@ describe('filterResponse helper', () => {
       assert.isNumber(balance)
     })
   })
+
+  it('it should be successful by not consider capital letters', function () {
+    this.timeout(1000)
+
+    const res = filterResponse(
+      mockData,
+      {
+        $eq: { wallet: 'fUnding' },
+        $ne: {
+          description: 'wire withDRaWal #13002753 on wallet funding'
+        },
+        $like: { description: 'trading fees%' },
+        $nin: { currency: ['uSD'] },
+        $in: { currency: ['LEO'] }
+      }
+    )
+
+    assert.isAbove(res.length, 0)
+
+    res.forEach((
+      {
+        currency,
+        description,
+        wallet
+      }
+    ) => {
+      assert.strictEqual(wallet, 'funding')
+      assert.notStrictEqual(
+        description,
+        'Wire Withdrawal #13002753 on wallet funding'
+      )
+      assert.match(description, /^Trading fees/)
+      assert.notInclude(['USD'], currency)
+      assert.include(['LEO'], currency)
+    })
+  })
 })

--- a/workers/loc.api/helpers/filter-response.js
+++ b/workers/loc.api/helpers/filter-response.js
@@ -40,15 +40,26 @@ const _isNull = (val) => {
 }
 
 const _toLowerCaseStr = (value, isNotIgnoreCase) => {
-  if (
-    isNotIgnoreCase ||
-    !value ||
-    typeof value !== 'string'
-  ) {
-    return value
-  }
+  const isArray = Array.isArray(value)
+  const valueArr = isArray
+    ? value
+    : [value]
 
-  return value.toLowerCase()
+  const resArr = valueArr.map((item) => {
+    if (
+      isNotIgnoreCase ||
+      !item ||
+      typeof item !== 'string'
+    ) {
+      return item
+    }
+
+    return item.toLowerCase()
+  })
+
+  return isArray
+    ? resArr
+    : resArr[0]
 }
 
 const _getComparator = (

--- a/workers/loc.api/helpers/filter-response.js
+++ b/workers/loc.api/helpers/filter-response.js
@@ -39,8 +39,9 @@ const _isNull = (val) => {
   )
 }
 
-const _toLowerCaseStr = (value) => {
+const _toLowerCaseStr = (value, isNotIgnoreCase) => {
   if (
+    isNotIgnoreCase ||
     !value ||
     typeof value !== 'string'
   ) {
@@ -52,25 +53,26 @@ const _toLowerCaseStr = (value) => {
 
 const _getComparator = (
   fieldName,
-  inputValue
+  inputValue,
+  isNotIgnoreCase
 ) => {
-  const value = _toLowerCaseStr(inputValue)
+  const value = _toLowerCaseStr(inputValue, isNotIgnoreCase)
 
   const eqFn = (item) => (
     !_isNull(item) &&
-    _toLowerCaseStr(item) === value
+    _toLowerCaseStr(item, isNotIgnoreCase) === value
   )
   const neFn = (item) => (
     !_isNull(item) &&
-    _toLowerCaseStr(item) !== value
+    _toLowerCaseStr(item, isNotIgnoreCase) !== value
   )
   const inFn = (item) => value.some((subItem) => (
     !_isNull(item) &&
-    _toLowerCaseStr(item) === subItem
+    _toLowerCaseStr(item, isNotIgnoreCase) === subItem
   ))
   const ninFn = (item) => value.every((subItem) => (
     !_isNull(item) &&
-    _toLowerCaseStr(item) !== subItem
+    _toLowerCaseStr(item, isNotIgnoreCase) !== subItem
   ))
   const likeFn = (item) => {
     const escapeRegExp = RegExp(`[${SPECIAL_CHARS.join('\\')}]`, 'g')
@@ -82,7 +84,7 @@ const _getComparator = (
 
     return (
       typeof item === 'string' &&
-      regexp.test(_toLowerCaseStr(item))
+      regexp.test(_toLowerCaseStr(item, isNotIgnoreCase))
     )
   }
 
@@ -183,7 +185,8 @@ const _getIsNullComparator = (
 
 module.exports = (
   data = [],
-  filter = {}
+  filter = {},
+  isNotIgnoreCase
 ) => {
   if (
     !filter ||
@@ -247,7 +250,8 @@ module.exports = (
             (condAccum, curr) => {
               const comparator = _getComparator(
                 fieldName,
-                condFilter[curr]
+                condFilter[curr],
+                isNotIgnoreCase
               )
 
               accum.push(() => comparator(item[curr]))
@@ -262,7 +266,8 @@ module.exports = (
 
         const comparator = _getComparator(
           fieldName,
-          value
+          value,
+          isNotIgnoreCase
         )
         accum.push(() => comparator(item[fieldName]))
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -265,7 +265,8 @@ const prepareResponse = (
   )
     ? filterResponse(
       apiRes,
-      { $in: { [symbPropName]: symbols } }
+      { $in: { [symbPropName]: symbols } },
+      true
     )
     : apiRes
   const res = filterResponse(


### PR DESCRIPTION
This PR fixes an issue on many responses with the same `mts`
The issue is when a user that hits this limit: https://github.com/bitfinexcom/bfx-report/blob/0386cd24204fb5f0fbf040155d1d49c3ef20e802/workers/loc.api/helpers/limit-param.helpers.js#L8
Applies the following logic:
  - when hit `max` and all entries have the same `mts`, make a new request with `innerMax` value
```
const _methodsLimits = {
    tickersHistory: { default: 100, max: 250, innerMax: 10000 },
    positionsHistory: { default: 25, max: 50, innerMax: 10000 },
    positionsAudit: { default: 100, max: 250, innerMax: 2500 },
    ledgers: { default: 250, max: 500, innerMax: 2500 },
    trades: { default: 500, max: 1000, innerMax: 2500 },
    orderTrades: { default: 500, max: 1000, innerMax: 2500 },
    fundingTrades: { default: 500, max: 1000, innerMax: 1000 },
    publicTrades: { default: 500, max: 5000, innerMax: 5000 },
    orders: { default: 250, max: 500, innerMax: 2500 },
    movements: { default: 25, max: 25, innerMax: 250 },
    fundingOfferHistory: { default: 100, max: 500, innerMax: 10000 },
    fundingLoanHistory: { default: 100, max: 500, innerMax: 10000 },
    fundingCreditHistory: { default: 100, max: 500, innerMax: 10000 },
    ...methodsLimits
  }
```