### PR TITLE
Check current and previous result for same data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep, isObject } = require('lodash')
 const moment = require('moment-timezone')
 
 const _validTxtTimeZone = (val, timezone, format) => {
@@ -209,10 +209,34 @@ const progress = (
   queue.emit('progress', percent)
 }
 
+const isSameRes = (prev = [], curr = []) => {
+  if (
+    !Array.isArray(prev) ||
+    prev.length === 0 ||
+    !Array.isArray(curr) ||
+    curr.length === 0
+  ) {
+    return false
+  }
+
+  const keys = Object.entries(prev[0])
+    .filter(([key, val]) => (/^(?!_)/.test(key)) && !isObject(val))
+    .map(([key]) => key)
+
+  return curr.some(currItem => {
+    return prev.some(prevItem => {
+      return keys.every(key => {
+        return prevItem[key] === currItem[key]
+      })
+    })
+  })
+}
+
 module.exports = {
   writeMessageToStream,
   setDefaultPrams,
   filterMovementsByAmount,
   write,
-  progress
+  progress,
+  isSameRes
 }

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -8,7 +8,8 @@ const {
   setDefaultPrams,
   filterMovementsByAmount,
   write,
-  progress
+  progress,
+  isSameRes
 } = require('./helpers')
 
 module.exports = (
@@ -41,7 +42,9 @@ module.exports = (
   const getData = rService[method].bind(rService)
 
   let count = 0
+  let reqCount = 0
   let serialRequestsCount = 0
+  let prevRes = []
 
   while (true) {
     processorQueue.emit('progress', 0)
@@ -51,6 +54,7 @@ module.exports = (
       currIterationArgs
     )
 
+    reqCount += 1
     const isGetWalletsMethod = method === 'getWallets'
     const isGetActivePositionsMethod = (
       method === 'getActivePositions'
@@ -86,13 +90,16 @@ module.exports = (
     if (
       !res ||
       !Array.isArray(res) ||
-      res.length === 0
+      res.length === 0 ||
+      isSameRes(prevRes, res) ||
+      reqCount > 100000
     ) {
       if (count > 0) processorQueue.emit('progress', 100)
 
       break
     }
 
+    prevRes = res
     const lastItem = res[res.length - 1]
 
     if (


### PR DESCRIPTION
This PR adds checking current and previous result for the same data when csv files are generated to avoid looping when `api_v2` is not taken to consideration timeframe parameters