### PR TITLE
Remove redundant test coverage of wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -422,40 +422,6 @@ describe('API', () => {
     ])
   })
 
-  it('it should be successfully performed by the getWallets method', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/get-data`)
-      .type('json')
-      .send({
-        auth,
-        method: 'getWallets',
-        params: {
-          end
-        },
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isArray(res.body.result)
-
-    const resItem = res.body.result[0]
-
-    assert.isObject(resItem)
-    assert.containsAllKeys(resItem, [
-      'type',
-      'currency',
-      'balance',
-      'unsettledInterest',
-      'balanceAvailable',
-      'mtsUpdate'
-    ])
-  })
-
   it('it should be successfully performed by the getWallets method, without params', async function () {
     this.timeout(5000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -263,7 +263,6 @@ describe('Queue', () => {
         auth,
         method: 'getWalletsCsv',
         params: {
-          end,
           email
         },
         id: 5

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -57,10 +57,6 @@ const setDataTo = (
       dataItem[15] = _date
       break
 
-    case 'wallets_hist':
-      dataItem[6] = _date
-      break
-
     case 'positions_hist':
       dataItem[11] = id
       dataItem[12] = _date
@@ -151,7 +147,6 @@ const setDataTo = (
 
 const getMockDataOpts = () => ({
   tickers_hist: { limit: 250 },
-  wallets_hist: { limit: 100, isNotMoreThanLimit: true },
   wallets: { limit: 100, isNotMoreThanLimit: true },
   positions_hist: { limit: 50 },
   positions: { limit: 50 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -71,18 +71,6 @@ module.exports = new Map([
     ]]
   ],
   [
-    'wallets_hist',
-    [[
-      'margin',
-      'BTC',
-      -0.04509854,
-      null,
-      null,
-      null,
-      _ms
-    ]]
-  ],
-  [
     'positions_hist',
     [[
       'tBTCUSD',

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -12,7 +12,8 @@ const {
   checkParams,
   getCsvArgs,
   checkTimeLimit,
-  checkJobAndGetUserData
+  checkJobAndGetUserData,
+  parsePositionsAuditId
 } = require('../helpers')
 const {
   FindMethodToGetCsvFileError,
@@ -311,19 +312,20 @@ class CsvJobData {
     uId,
     uInfo
   ) {
-    checkParams(args, 'paramsSchemaForPositionsAuditCsv', ['id'])
+    const _args = parsePositionsAuditId(args)
+    checkParams(_args, 'paramsSchemaForPositionsAuditCsv', ['id'])
 
     const {
       userId,
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
+      _args,
       uId,
       uInfo
     )
 
-    const csvArgs = getCsvArgs(args, 'positionsAudit')
+    const csvArgs = getCsvArgs(_args, 'positionsAudit')
 
     const jobData = {
       userInfo,

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -27,7 +27,8 @@ const {
 const {
   accountCache,
   parseFields,
-  parseLoginsExtraDataFields
+  parseLoginsExtraDataFields,
+  parsePositionsAuditId
 } = require('./utils')
 const checkJobAndGetUserData = require(
   './check-job-and-get-user-data'
@@ -65,5 +66,6 @@ module.exports = {
   checkFilterParams,
   FILTER_MODELS_NAMES,
   FILTER_CONDITIONS,
-  getDataFromApi
+  getDataFromApi,
+  parsePositionsAuditId
 }

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -49,8 +49,27 @@ const parseLoginsExtraDataFields = (res) => {
   })
 }
 
+const parsePositionsAuditId = (args) => {
+  const { params } = { ...args }
+  const { id } = { ...params }
+  const parsedId = Array.isArray(id)
+    ? id.map(_id => (
+      typeof _id === 'string' ? Number.parseInt(_id) : _id)
+    )
+    : id
+
+  return {
+    ...args,
+    params: {
+      ...params,
+      id: parsedId
+    }
+  }
+}
+
 module.exports = {
   accountCache,
   parseFields,
-  parseLoginsExtraDataFields
+  parseLoginsExtraDataFields,
+  parsePositionsAuditId
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -203,11 +203,8 @@ class ReportService extends Api {
       checkParams(args, 'paramsSchemaForWallets')
 
       const rest = this._getREST(args.auth)
-      const { end } = { ...args.params }
 
-      return end
-        ? rest.walletsHistory(end)
-        : rest.wallets()
+      return rest.wallets()
     }, 'getWallets', cb)
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -8,7 +8,8 @@ const {
   parseLoginsExtraDataFields,
   accountCache,
   getTimezoneConf,
-  filterModels
+  filterModels,
+  parsePositionsAuditId
 } = require('./helpers')
 const { ArgsParamsError } = require('./errors')
 const TYPES = require('./di/types')
@@ -187,8 +188,10 @@ class ReportService extends Api {
 
   getPositionsAudit (space, args, cb) {
     return this._responder(() => {
+      const _args = parsePositionsAuditId(args)
+
       return this._prepareApiResponse(
-        args,
+        _args,
         'positionsAudit',
         {
           datePropName: 'mtsUpdate',


### PR DESCRIPTION
This PR removes redundant test coverage of the `getWallets` endpoint
These changes are related to this PR [bfx-report#171](https://github.com/bitfinexcom/bfx-report/pull/171)