### PR TITLE
Add changeLogs endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -73,9 +73,10 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/check-auth`)
+      .post(`${basePath}/get-data`)
       .type('json')
       .send({
+        method: 'verifyUser',
         auth,
         id: 5
       })
@@ -83,7 +84,13 @@ describe('API', () => {
       .expect(200)
 
     assert.isObject(res.body)
-    assert.propertyVal(res.body, 'result', true)
+    assert.isObject(res.body.result)
+    assert.isString(res.body.result.username)
+    assert.isString(res.body.result.timezone)
+    assert.isString(res.body.result.email)
+    assert.isNumber(res.body.result.id)
+    assert.isBoolean(res.body.result.isSubAccount)
+    assert.strictEqual(res.body.result.email, 'fake@email.fake')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -120,19 +127,25 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/check-auth`)
+      .post(`${basePath}/get-data`)
       .type('json')
       .send({
-        auth: {
-          authToken: 'fake'
-        },
+        method: 'verifyUser',
+        auth: { authToken: 'fake' },
         id: 5
       })
       .expect('Content-Type', /json/)
       .expect(200)
 
     assert.isObject(res.body)
-    assert.propertyVal(res.body, 'result', true)
+    assert.isObject(res.body.result)
+    assert.isString(res.body.result.username)
+    assert.isString(res.body.result.timezone)
+    assert.isString(res.body.result.email)
+    assert.isNumber(res.body.result.id)
+    assert.isBoolean(res.body.result.isSubAccount)
+    assert.strictEqual(res.body.result.email, 'fake@email.fake')
+    assert.propertyVal(res.body, 'id', 5)
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -140,9 +153,10 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/check-auth`)
+      .post(`${basePath}/get-data`)
       .type('json')
       .send({
+        method: 'verifyUser',
         auth: {
           apiKey: '',
           apiSecret: ''
@@ -173,26 +187,8 @@ describe('API', () => {
 
     assert.isObject(res.body)
     assert.isString(res.body.result)
+    assert.strictEqual(res.body.result, 'fake@email.fake')
     assert.propertyVal(res.body, 'id', 5)
-  })
-
-  it('it should be successfully performed by the getEmail method', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/get-data`)
-      .type('json')
-      .send({
-        auth,
-        method: 'getEmail',
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isOk(res.body.result === 'fake@email.fake')
   })
 
   it('it should be successfully performed by the getUsersTimeConf method', async function () {

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1408,6 +1408,42 @@ describe('API', () => {
     assert.isObject(resItem.extraData)
   })
 
+  it('it should be successfully performed by the getChangeLogs method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getChangeLogs',
+        params: {
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'mtsCreate',
+      'log',
+      'ip',
+      'userAgent'
+    ])
+  })
+
   it('it should not be successfully performed by a fake method', async function () {
     this.timeout(5000)
 

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -55,7 +55,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'isSyncModeConfig',
@@ -73,7 +73,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'verifyUser',
@@ -98,7 +98,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getFilterModels',
@@ -127,7 +127,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'verifyUser',
@@ -153,7 +153,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'verifyUser',
@@ -195,7 +195,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -215,7 +215,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -247,7 +247,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -285,7 +285,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -331,7 +331,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -372,7 +372,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -422,7 +422,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -452,7 +452,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -501,7 +501,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -551,7 +551,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -602,7 +602,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -642,7 +642,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -676,7 +676,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -720,7 +720,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -764,7 +764,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -808,7 +808,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -849,7 +849,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getPublicTrades',
@@ -885,7 +885,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getStatusMessages',
@@ -921,7 +921,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getCandles',
@@ -959,7 +959,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getPublicTrades',
@@ -995,7 +995,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getPublicTrades',
@@ -1021,7 +1021,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1066,7 +1066,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1094,7 +1094,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1139,7 +1139,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1191,7 +1191,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1235,7 +1235,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1278,7 +1278,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1315,7 +1315,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1337,7 +1337,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1375,7 +1375,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1412,7 +1412,7 @@ describe('API', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1436,7 +1436,7 @@ describe('API', () => {
     mockRESTv2Srv = createMockRESTv2SrvWithAllData()
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -1466,7 +1466,7 @@ describe('API', () => {
     mockRESTv2Srv = createMockRESTv2SrvWithAllData()
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,

--- a/test/2-api-filter.spec.js
+++ b/test/2-api-filter.spec.js
@@ -543,7 +543,7 @@ describe('API filter', () => {
 
     for (const { args, responseTest } of argsArr) {
       const res = await agent
-        .post(`${basePath}/get-data`)
+        .post(`${basePath}/json-rpc`)
         .type('json')
         .send(args)
         .expect('Content-Type', /json/)
@@ -630,7 +630,7 @@ describe('API filter', () => {
 
     for (const { args } of argsArr) {
       const res = await agent
-        .post(`${basePath}/get-data`)
+        .post(`${basePath}/json-rpc`)
         .type('json')
         .send(args)
         .expect('Content-Type', /json/)
@@ -651,7 +651,7 @@ describe('API filter', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -682,7 +682,7 @@ describe('API filter', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,

--- a/test/3-report-signature.spec.js
+++ b/test/3-report-signature.spec.js
@@ -86,7 +86,7 @@ describe('Signature', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -127,7 +127,7 @@ describe('Signature', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -153,7 +153,7 @@ describe('Signature', () => {
     this.timeout(5000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -766,6 +766,32 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getChangeLogsCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getChangeLogsCsv',
+        params: {
+          end,
+          start,
+          limit: 1000,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
     this.timeout(60000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -77,7 +77,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -115,7 +115,7 @@ describe('Queue', () => {
     this.timeout(60000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -151,7 +151,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -179,7 +179,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -206,7 +206,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -229,7 +229,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -257,7 +257,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -280,7 +280,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -308,7 +308,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -335,7 +335,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -362,7 +362,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -390,7 +390,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -418,7 +418,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -446,7 +446,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -471,7 +471,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -499,7 +499,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -524,7 +524,7 @@ describe('Queue', () => {
     this.timeout(60000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -553,7 +553,7 @@ describe('Queue', () => {
     this.timeout(60000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -585,7 +585,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -614,7 +614,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -641,7 +641,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -664,7 +664,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -691,7 +691,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -719,7 +719,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -747,7 +747,7 @@ describe('Queue', () => {
     const aggrPromise = queueToPromise(aggregatorQueue)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         auth,
@@ -770,7 +770,7 @@ describe('Queue', () => {
     this.timeout(60000)
 
     const res = await agent
-      .post(`${basePath}/get-data`)
+      .post(`${basePath}/json-rpc`)
       .type('json')
       .send({
         method: 'getLedgersCsv',
@@ -808,7 +808,7 @@ describe('Queue', () => {
 
     for (let i = 0; i < count; i += 1) {
       const res = await agent
-        .post(`${basePath}/get-data`)
+        .post(`${basePath}/json-rpc`)
         .type('json')
         .send({
           auth,

--- a/test/5-queue-load.spec.js
+++ b/test/5-queue-load.spec.js
@@ -94,7 +94,7 @@ describe('Queue load', () => {
 
     for (let i = 0; i < count; i += 1) {
       const res = await agent
-        .post(`${basePath}/get-data`)
+        .post(`${basePath}/json-rpc`)
         .type('json')
         .send({
           auth,

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -43,6 +43,10 @@ const setDataTo = (
       dataItem[0] = _date
       break
 
+    case 'change_log':
+      dataItem[0] = _date
+      break
+
     case 'logins_hist':
       dataItem[0] = id
       dataItem[2] = _date
@@ -164,6 +168,7 @@ const getMockDataOpts = () => ({
   f_loan_hist: { limit: 500 },
   f_credit_hist: { limit: 500 },
   logins_hist: { limit: 250 },
+  change_log: { limit: 500 },
   candles: { limit: 500 },
   user_info: null,
   symbols: null,

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -527,6 +527,18 @@ module.exports = new Map([
     ]]
   ],
   [
+    'change_log',
+    [[
+      _ms,
+      null,
+      'settings: timezone',
+      null,
+      null,
+      '127.0.0.1',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
+    ]]
+  ],
+  [
     'candles',
     [[
       _ms,

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -106,7 +106,8 @@ module.exports = ({
         [
           TYPES.ProcessorQueue,
           TYPES.HasGrcService,
-          TYPES.CsvJobData
+          TYPES.CsvJobData,
+          TYPES.RService
         ]
       ))
     bind(TYPES.WriteDataToStream).toConstantValue(

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -887,6 +887,44 @@ class CsvJobData {
     return jobData
   }
 
+  async getChangeLogsCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args, 'changeLogs')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getChangeLogs',
+      args: csvArgs,
+      propNameForPagination: 'mtsCreate',
+      columnsCsv: {
+        mtsCreate: 'DATE',
+        log: 'LOG',
+        ip: 'IP',
+        userAgent: 'USER AGENT'
+      },
+      formatSettings: {
+        time: 'mtsCreate'
+      }
+    }
+
+    return jobData
+  }
+
   async getMultipleCsvJobData (
     args,
     uId,

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -37,7 +37,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -81,7 +80,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -125,7 +123,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -187,7 +184,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -220,7 +216,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -268,7 +263,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -320,7 +314,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      _args,
       uId,
       uInfo
     )
@@ -371,7 +364,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -426,7 +418,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -468,7 +459,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -509,7 +499,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -551,7 +540,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -595,7 +583,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -644,7 +631,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -691,7 +677,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -734,7 +719,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -781,7 +765,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -830,7 +813,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -880,7 +862,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )
@@ -918,7 +899,6 @@ class CsvJobData {
       userInfo
     } = await checkJobAndGetUserData(
       this.rService,
-      args,
       uId,
       uInfo
     )

--- a/workers/loc.api/generate-csv/index.js
+++ b/workers/loc.api/generate-csv/index.js
@@ -74,11 +74,14 @@ const _getFilterModelNamesAndArgs = (
 module.exports = (
   processorQueue,
   hasGrcService,
-  csvJobData
+  csvJobData,
+  rService
 ) => async (
   name,
   args
 ) => {
+  const user = await rService.verifyUser(null, args)
+
   const status = await _getCsvStoreStatus(
     hasGrcService,
     args
@@ -93,7 +96,7 @@ module.exports = (
   }
 
   const getter = csvJobData[name].bind(csvJobData)
-  const jobData = await getter(args)
+  const jobData = await getter(args, null, user)
 
   processorQueue.addJob(jobData)
 

--- a/workers/loc.api/helpers/check-job-and-get-user-data.js
+++ b/workers/loc.api/helpers/check-job-and-get-user-data.js
@@ -5,30 +5,19 @@ const hasJobInQueueWithStatusBy = require(
 )
 
 module.exports = async (
-  reportService,
-  args,
+  rService,
   uId,
-  uInfo
+  user
 ) => {
+  const { id } = { ...user }
+
   const userId = Number.isInteger(uId)
     ? uId
-    : await hasJobInQueueWithStatusBy(reportService, args)
+    : await hasJobInQueueWithStatusBy(rService, user)
 
-  const {
-    username,
-    email,
-    id
-  } = { ...uInfo }
-  const _userInfo = (
-    username && typeof username === 'string' &&
-    email && typeof email === 'string' &&
-    Number.isInteger(id)
-  )
-    ? uInfo
-    : await reportService._getUserInfo(args)
   const userInfo = {
-    ..._userInfo,
-    userId: _userInfo.id
+    ...user,
+    userId: id
   }
 
   return {

--- a/workers/loc.api/helpers/filter-models.js
+++ b/workers/loc.api/helpers/filter-models.js
@@ -214,6 +214,15 @@ module.exports = new Map([
     }
   ],
   [
+    FILTER_MODELS_NAMES.CHANGE_LOGS,
+    {
+      mtsCreate: { type: 'integer' },
+      log: { type: 'string' },
+      ip: { type: 'string', format: 'ipv4' },
+      userAgent: { type: 'string' }
+    }
+  ],
+  [
     FILTER_MODELS_NAMES.CANDLES,
     {
       mts: { type: 'integer' },

--- a/workers/loc.api/helpers/filter.models.names.js
+++ b/workers/loc.api/helpers/filter.models.names.js
@@ -24,5 +24,6 @@ module.exports = {
   FUNDING_CREDIT_HISTORY: 'fundingCreditHistory',
   STATUS_MESSAGES: 'statusMessages',
   LOGINS: 'logins',
+  CHANGE_LOGS: 'changeLogs',
   CANDLES: 'candles'
 }

--- a/workers/loc.api/helpers/has-job-in-queue-with-status-by.js
+++ b/workers/loc.api/helpers/has-job-in-queue-with-status-by.js
@@ -3,25 +3,26 @@
 const { QueueJobAddingError } = require('../errors')
 
 module.exports = async (
-  reportService,
-  args,
+  rService,
+  user,
   statuses = ['ACTIVE', 'PROCESSING']
 ) => {
-  const ctx = reportService.ctx
+  const ctx = rService.ctx
   const wrk = ctx.grc_bfx.caller
   const group = wrk.group
-  const conf = wrk.conf[group]
+  const {
+    syncMode,
+    isSpamRestrictionMode
+  } = { ...wrk.conf[group] }
 
   if (
-    conf.syncMode ||
-    !conf.isSpamRestrictionMode
+    syncMode ||
+    !isSpamRestrictionMode
   ) {
-    await reportService.verifyUser(null, args)
-
     return null
   }
 
-  const userInfo = await reportService._getUserInfo(args)
+  const { id } = { ...user }
 
   const procQ = ctx.lokue_processor.q
   const aggrQ = ctx.lokue_aggregator.q
@@ -34,14 +35,12 @@ module.exports = async (
         return true
       }
 
-      return jobs.every(job => {
-        return (
-          typeof job === 'object' &&
-          typeof job.data === 'object' &&
-          typeof job.data.userId !== 'undefined' &&
-          job.data.userId !== userInfo.id
-        )
-      })
+      return jobs.every(job => (
+        typeof job === 'object' &&
+        typeof job.data === 'object' &&
+        typeof job.data.userId !== 'undefined' &&
+        job.data.userId !== id
+      ))
     })
   }))
 
@@ -49,5 +48,5 @@ module.exports = async (
     throw new QueueJobAddingError()
   }
 
-  return userInfo.id
+  return id
 }

--- a/workers/loc.api/helpers/has-job-in-queue-with-status-by.js
+++ b/workers/loc.api/helpers/has-job-in-queue-with-status-by.js
@@ -16,7 +16,7 @@ module.exports = async (
     conf.syncMode ||
     !conf.isSpamRestrictionMode
   ) {
-    await reportService.getEmail(null, args)
+    await reportService.verifyUser(null, args)
 
     return null
   }

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -17,6 +17,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     fundingCreditHistory: { default: 100, max: 500, innerMax: 500 },
     logins: { default: 100, max: 250, innerMax: 250 },
     candles: { default: 500, max: 500, innerMax: 10000 },
+    changeLogs: { default: 500, max: 500, innerMax: 500 },
     ...methodsLimits
   }
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -45,6 +45,11 @@ const _paramsOrderMap = {
     'end',
     'limit'
   ],
+  changeLogs: [
+    'start',
+    'end',
+    'limit'
+  ],
   default: [
     'symbol',
     'start',

--- a/workers/loc.api/queue/helpers/get-complete-file-name.js
+++ b/workers/loc.api/queue/helpers/get-complete-file-name.js
@@ -20,7 +20,9 @@ const _fileNamesMap = new Map([
   ['getPositionsAudit', 'positions_audit'],
   ['getWallets', 'wallets'],
   ['getTickersHistory', 'tickers_history'],
-  ['getActivePositions', 'active_positions']
+  ['getActivePositions', 'active_positions'],
+  ['getLogins', 'logins'],
+  ['getChangeLogs', 'change_logs']
 ])
 
 const _getBaseName = (

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -75,23 +75,12 @@ class ReportService extends Api {
     }, 'isSyncModeConfig', cb)
   }
 
-  getEmail (space, args, cb) {
+  verifyUser (space, args, cb) {
     return this._responder(async () => {
       const { email } = await this._getUserInfo(args)
 
-      return email
-    }, 'getEmail', cb)
-  }
-
-  login (space, args, cb, isInnerCall) {
-    return this._responder(async () => {
-      const userInfo = await this._getUserInfo(args)
-      const isSyncModeConfig = this.isSyncModeConfig()
-
-      return isInnerCall
-        ? { ...userInfo, isSyncModeConfig }
-        : userInfo.email
-    }, 'login', cb)
+      return { email, isSubAccount: false }
+    }, 'verifyUser', cb)
   }
 
   getUsersTimeConf (space, args, cb) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -649,6 +649,15 @@ class ReportService extends Api {
       )
     }, 'getLoginsCsv', cb)
   }
+
+  getChangeLogsCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getChangeLogsCsvJobData',
+        args
+      )
+    }, 'getChangeLogsCsv', cb)
+  }
 }
 
 module.exports = ReportService

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,7 +11,10 @@ const {
   filterModels,
   parsePositionsAuditId
 } = require('./helpers')
-const { ArgsParamsError } = require('./errors')
+const {
+  ArgsParamsError,
+  AuthError
+} = require('./errors')
 const TYPES = require('./di/types')
 
 class ReportService extends Api {
@@ -77,9 +80,24 @@ class ReportService extends Api {
 
   verifyUser (space, args, cb) {
     return this._responder(async () => {
-      const { email } = await this._getUserInfo(args)
+      const {
+        username,
+        timezone,
+        email,
+        id
+      } = await this._getUserInfo(args)
 
-      return { email, isSubAccount: false }
+      if (!email) {
+        throw new AuthError()
+      }
+
+      return {
+        username,
+        timezone,
+        email,
+        id,
+        isSubAccount: false
+      }
     }, 'verifyUser', cb)
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -458,6 +458,18 @@ class ReportService extends Api {
     }, 'getLogins', cb)
   }
 
+  changeLogs (space, args, cb) {
+    return this._responder(() => {
+      return this._prepareApiResponse(
+        args,
+        'changeLogs',
+        {
+          datePropName: 'mtsCreate'
+        }
+      )
+    }, 'changeLogs', cb)
+  }
+
   getMultipleCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -458,7 +458,7 @@ class ReportService extends Api {
     }, 'getLogins', cb)
   }
 
-  changeLogs (space, args, cb) {
+  getChangeLogs (space, args, cb) {
     return this._responder(() => {
       return this._prepareApiResponse(
         args,
@@ -467,7 +467,7 @@ class ReportService extends Api {
           datePropName: 'mtsCreate'
         }
       )
-    }, 'changeLogs', cb)
+    }, 'getChangeLogs', cb)
   }
 
   getMultipleCsv (space, args, cb) {


### PR DESCRIPTION
This PR adds changeLogs endpoints. Basic changes:
  - adds `getChangeLogs` method to the main service
  - adds `getChangeLogsCsv` method to the main service
  - adds corresponding test coverage

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/174