### PR TITLE
Reduce response payload

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -172,25 +172,6 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', null)
   })
 
-  it('it should be successfully check, csv is stored locally', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/check-stored-locally`)
-      .type('json')
-      .send({
-        auth,
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.isString(res.body.result)
-    assert.strictEqual(res.body.result, 'fake@email.fake')
-    assert.propertyVal(res.body, 'id', 5)
-  })
-
   it('it should be successfully performed by the getUsersTimeConf method', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -408,7 +408,8 @@ const _omitPrivateModelFields = (res) => {
     '_eventsCount',
     '_fields',
     '_boolFields',
-    '_fieldKeys'
+    '_fieldKeys',
+    '_apiInterface'
   ]
 
   if (

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,10 +11,7 @@ const {
   filterModels,
   parsePositionsAuditId
 } = require('./helpers')
-const {
-  ArgsParamsError,
-  AuthError
-} = require('./errors')
+const { AuthError } = require('./errors')
 const TYPES = require('./di/types')
 
 class ReportService extends Api {
@@ -113,21 +110,6 @@ class ReportService extends Api {
 
       return getTimezoneConf(timezone)
     }, 'getUsersTimeConf', cb)
-  }
-
-  lookUpFunction (space, args, cb) {
-    return this._responder(() => {
-      if (
-        !args.params ||
-        typeof args.params !== 'object'
-      ) {
-        throw new ArgsParamsError()
-      }
-
-      const { service } = { ...args.params }
-
-      return this._hasGrcService.lookUpFunction(service)
-    }, 'lookUpFunction', cb)
   }
 
   getSymbols (space, args, cb) {


### PR DESCRIPTION
This PR reduces the response payload. The issue is in response of the `getPositionsAudit` method was noticed redundant `_apiInterface` object which one is proxied from the `bitfinex-api-node`:

```json
"_apiInterface": {
  "_url": "https://api-pub.bitfinex.com",
  "_apiKey": "---",
  "_apiSecret": "---",
  "_authToken": "",
  "_company": "bitfinex",
  "_transform": true,
  "_rest1": {
      "_url": "https://api-pub.bitfinex.com",
      "_apiKey": "---",
      "_apiSecret": "---"
  }
}
```