### PR TITLE
Fix csv export with searching by filter

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -226,6 +226,64 @@ describe('API', () => {
     })
   })
 
+  it('it should be successfully performed by the updateSettings method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'updateSettings',
+        params: {
+          settings: { 'api:testKey': { value: 'strVal' } }
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isNumber(res.body.result[0])
+    assert.isString(res.body.result[1])
+    assert.strictEqual(res.body.result[1], 'acc_ss')
+    assert.isArray(res.body.result[4])
+    assert.isNumber(res.body.result[4][0])
+    assert.strictEqual(res.body.result[4][0], 1)
+    assert.isString(res.body.result[6])
+    assert.strictEqual(res.body.result[6], 'SUCCESS')
+  })
+
+  it('it should be successfully performed by the getSettings method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getSettings',
+        params: {
+          keys: ['api:testKey']
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.isArray(res.body.result[0])
+    assert.isString(res.body.result[0][0])
+    assert.strictEqual(res.body.result[0][0], 'testKey')
+    assert.isObject(res.body.result[0][1])
+    assert.isString(res.body.result[0][1].value)
+    assert.strictEqual(res.body.result[0][1].value, 'strVal')
+  })
+
   it('it should be successfully performed by the getTickersHistory method', async function () {
     this.timeout(5000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -175,7 +175,9 @@ const getMockDataOpts = () => ({
   inactive_symbols: null,
   futures: null,
   currencies: null,
-  account_summary: null
+  account_summary: null,
+  get_settings: null,
+  set_settings: null
 })
 
 const createMockRESTv2SrvWithDate = (

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -575,5 +575,25 @@ module.exports = new Map([
       12345,
       12345
     ]]
+  ],
+  [
+    'get_settings',
+    [[
+      'testKey',
+      { value: 'strVal' }
+    ]]
+  ],
+  [
+    'set_settings',
+    [
+      _ms,
+      'acc_ss',
+      null,
+      null,
+      [1],
+      null,
+      'SUCCESS',
+      null
+    ]
   ]
 ])

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -74,7 +74,7 @@ module.exports = (
       res.length === 0 &&
       nextPage &&
       Number.isInteger(nextPage) &&
-      serialRequestsCount < 1
+      serialRequestsCount < 1000
     ) {
       serialRequestsCount += 1
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -139,6 +139,28 @@ class ReportService extends Api {
     }, 'getSymbols', cb)
   }
 
+  getSettings (space, args, cb) {
+    return this._responder(async () => {
+      const { auth, params } = { ...args }
+      const { keys = [] } = { ...params }
+
+      const rest = this._getREST(auth)
+
+      return rest.getSettings(keys)
+    }, 'getSettings', cb)
+  }
+
+  updateSettings (space, args, cb) {
+    return this._responder(async () => {
+      const { auth, params } = { ...args }
+      const { settings = {} } = { ...params }
+
+      const rest = this._getREST(auth)
+
+      return rest.updateSettings(settings)
+    }, 'updateSettings', cb)
+  }
+
   getTickersHistory (space, args, cb) {
     return this._responder(() => {
       const { symbol: s } = { ...args.params }


### PR DESCRIPTION
This PR fixes csv export with searching by a filter when the first responses are empty