### PR TITLE
Add ability to fetch positions snapshot

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -393,6 +393,51 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getPositionsSnapshot method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getPositionsSnapshot',
+        params: {
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'symbol',
+      'status',
+      'amount',
+      'basePrice',
+      'marginFunding',
+      'marginFundingType',
+      'pl',
+      'plPerc',
+      'liquidationPrice',
+      'leverage',
+      'id',
+      'mtsCreate',
+      'mtsUpdate'
+    ])
+  })
+
   it('it should be successfully performed by the getActivePositions method', async function () {
     this.timeout(5000)
 

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -94,6 +94,31 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the generateToken method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        method: 'generateToken',
+        auth,
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.lengthOf(res.body.result, 1)
+
+    res.body.result.forEach((token) => {
+      assert.isString(token)
+      assert.strictEqual(token, 'pub:api:12ab12ab-12ab-12ab-12ab-12ab12ab12ab-read')
+    })
+  })
+
   it('it should be successfully performed by the getFilterModels method', async function () {
     this.timeout(5000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -177,7 +177,8 @@ const getMockDataOpts = () => ({
   currencies: null,
   account_summary: null,
   get_settings: null,
-  set_settings: null
+  set_settings: null,
+  generate_token: null
 })
 
 const createMockRESTv2SrvWithDate = (

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -61,6 +61,12 @@ const setDataTo = (
       dataItem[15] = _date
       break
 
+    case 'positions_snap':
+      dataItem[11] = id
+      dataItem[12] = _date
+      dataItem[13] = _date
+      break
+
     case 'positions_hist':
       dataItem[11] = id
       dataItem[12] = _date
@@ -153,6 +159,7 @@ const getMockDataOpts = () => ({
   tickers_hist: { limit: 250 },
   wallets: { limit: 100, isNotMoreThanLimit: true },
   positions_hist: { limit: 50 },
+  positions_snap: { limit: 50 },
   positions: { limit: 50 },
   positions_audit: { limit: 250 },
   ledgers: { limit: 500 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -78,6 +78,25 @@ module.exports = new Map([
     ]]
   ],
   [
+    'positions_snap',
+    [[
+      'tBTCUSD',
+      'ACTIVE',
+      0.1,
+      16500,
+      0,
+      0,
+      null,
+      null,
+      null,
+      null,
+      null,
+      12345,
+      _ms,
+      _ms
+    ]]
+  ],
+  [
     'positions_hist',
     [[
       'tBTCUSD',

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -606,5 +606,11 @@ module.exports = new Map([
       'SUCCESS',
       null
     ]
+  ],
+  [
+    'generate_token',
+    [
+      'pub:api:12ab12ab-12ab-12ab-12ab-12ab12ab12ab-read'
+    ]
   ]
 ])

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -23,6 +23,7 @@ const uploadToS3 = require('../queue/upload-to-s3')
 const sendMail = require('../queue/send-mail')
 const generateCsv = require('../generate-csv')
 const CsvJobData = require('../generate-csv/csv.job.data')
+const Interrupter = require('../interrupter')
 
 module.exports = ({
   rService,
@@ -161,5 +162,7 @@ module.exports = ({
         ]
       )
     )
+    bind(TYPES.Interrupter)
+      .to(Interrupter)
   })
 }

--- a/workers/loc.api/di/index.js
+++ b/workers/loc.api/di/index.js
@@ -3,4 +3,4 @@
 require('reflect-metadata')
 const { Container } = require('inversify')
 
-module.exports = new Container()
+module.exports = new Container({ skipBaseClassChecks: true })

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -26,5 +26,6 @@ module.exports = {
   WriteDataToStream: Symbol.for('WriteDataToStream'),
   UploadToS3: Symbol.for('UploadToS3'),
   SendMail: Symbol.for('SendMail'),
-  CsvJobData: Symbol.for('CsvJobData')
+  CsvJobData: Symbol.for('CsvJobData'),
+  Interrupter: Symbol.for('Interrupter')
 }

--- a/workers/loc.api/helpers/check-filter-params.js
+++ b/workers/loc.api/helpers/check-filter-params.js
@@ -102,7 +102,10 @@ const _getFilterSchema = (model = {}) => {
 }
 
 const _getMethodApiName = (methodApi) => {
-  if (methodApi === FILTER_MODELS_NAMES.POSITIONS_AUDIT) {
+  if (
+    methodApi === FILTER_MODELS_NAMES.POSITIONS_AUDIT ||
+    methodApi === FILTER_MODELS_NAMES.POSITIONS_SNAPSHOT
+  ) {
     return FILTER_MODELS_NAMES.POSITIONS_HISTORY
   }
   if (methodApi === FILTER_MODELS_NAMES.ORDER_TRADES) {

--- a/workers/loc.api/helpers/filter.models.names.js
+++ b/workers/loc.api/helpers/filter.models.names.js
@@ -7,6 +7,10 @@ module.exports = {
   /**
    * It's an alias to POSITIONS_HISTORY model
    */
+  POSITIONS_SNAPSHOT: 'positionsSnapshot',
+  /**
+   * It's an alias to POSITIONS_HISTORY model
+   */
   POSITIONS_AUDIT: 'positionsAudit',
   LEDGERS: 'ledgers',
   TRADES: 'trades',

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -18,6 +18,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     logins: { default: 100, max: 250, innerMax: 250 },
     candles: { default: 500, max: 500, innerMax: 10000 },
     changeLogs: { default: 500, max: 500, innerMax: 500 },
+    positionsSnapshot: { default: 50, max: 500, innerMax: 500 },
     ...methodsLimits
   }
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -19,6 +19,11 @@ const {
 } = require('../errors')
 
 const _paramsOrderMap = {
+  positionsSnapshot: [
+    'start',
+    'end',
+    'limit'
+  ],
   statusMessages: [
     'type',
     'symbol'

--- a/workers/loc.api/interrupter/index.js
+++ b/workers/loc.api/interrupter/index.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const EventEmitter = require('events')
+const {
+  decorate,
+  injectable
+} = require('inversify')
+
+class Interrupter extends EventEmitter {
+  constructor () {
+    super()
+
+    this.INTERRUPT_EVENT = 'INTERRUPT_EVENT'
+    this.INTERRUPTED_EVENT = 'INTERRUPTED_EVENT'
+    this.INTERRUPTED_WITH_ERR_EVENT = 'ERR_INTERRUPTED_WITH_ERR_EVENT'
+
+    this._isInterrupted = false
+    this._interruptPromise = Promise.resolve()
+
+    this._init()
+  }
+
+  _init () {}
+
+  hasInterrupted () {
+    return this._isInterrupted
+  }
+
+  interrupt () {
+    if (this._isInterrupted) {
+      return this._interruptPromise
+    }
+
+    this._isInterrupted = true
+    this._interruptPromise = new Promise((resolve, reject) => {
+      try {
+        this.emit(this.INTERRUPT_EVENT)
+
+        const errorHandler = (err) => {
+          this.off(this.INTERRUPTED_EVENT, progressHandler)
+          this._isInterrupted = false
+
+          reject(err)
+        }
+        const progressHandler = (progress) => {
+          this.off(this.INTERRUPTED_WITH_ERR_EVENT, errorHandler)
+          this._isInterrupted = false
+
+          resolve(progress)
+        }
+
+        this.once(this.INTERRUPTED_WITH_ERR_EVENT, errorHandler)
+        this.once(this.INTERRUPTED_EVENT, progressHandler)
+      } catch (err) {
+        this._isInterrupted = false
+
+        reject(err)
+      }
+    })
+
+    return this._interruptPromise
+  }
+
+  onceInterrupt (cb) {
+    this.once(this.INTERRUPT_EVENT, cb)
+  }
+
+  offInterrupt (cb) {
+    this.off(this.INTERRUPT_EVENT, cb)
+  }
+
+  emitInterrupted (error, progress) {
+    if (error) {
+      this.emit(this.INTERRUPTED_WITH_ERR_EVENT, error)
+
+      return
+    }
+
+    this.emit(this.INTERRUPTED_EVENT, progress)
+  }
+}
+
+decorate(injectable(), Interrupter)
+
+module.exports = Interrupter

--- a/workers/loc.api/interrupter/index.js
+++ b/workers/loc.api/interrupter/index.js
@@ -16,11 +16,7 @@ class Interrupter extends EventEmitter {
 
     this._isInterrupted = false
     this._interruptPromise = Promise.resolve()
-
-    this._init()
   }
-
-  _init () {}
 
   hasInterrupted () {
     return this._isInterrupted

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -51,6 +51,19 @@ class ReportService extends Api {
     return rest.inactiveSymbols()
   }
 
+  getPositionsSnapshot (space, args, cb) {
+    return this._responder(() => {
+      return this._prepareApiResponse(
+        args,
+        'positionsSnapshot',
+        {
+          datePropName: 'mtsUpdate',
+          symbPropName: 'symbol'
+        }
+      )
+    }, 'getPositionsSnapshot', cb)
+  }
+
   getFilterModels (space, args, cb) {
     return this._responder(() => {
       const models = [...filterModels]

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -104,6 +104,20 @@ class ReportService extends Api {
     }, 'verifyUser', cb)
   }
 
+  generateToken (space, args, cb) {
+    return this._responder(async () => {
+      const { auth } = { ...args }
+      const rest = this._getREST(auth)
+
+      return rest.generateToken({
+        ttl: 3600,
+        scope: 'api',
+        writePermission: false,
+        _cust_ip: '0'
+      })
+    }, 'verifyUser', cb)
+  }
+
   getUsersTimeConf (space, args, cb) {
     return this._responder(async () => {
       const { timezone } = await this._getUserInfo(args)


### PR DESCRIPTION
This PR adds the ability to fetch positions snapshot from the API to sync in the framework part for `win/loss` section. Basic changes:
  - adds `getPositionsSnapshot` method to the main service
  - adds the corresponding test coverage
  - fixes DI (`InversifyJS`) base class checks issue:
https://github.com/inversify/InversifyJS/issues/522
https://github.com/inversify/InversifyJS/blob/master/wiki/inheritance.md#workaround-e-skip-base-class-injectable-checks