### PR TITLE
Change file name ending from uuid to serial number

### DIFF
--- a/test/simulate/simulate-enviroment.js
+++ b/test/simulate/simulate-enviroment.js
@@ -1,6 +1,14 @@
 'use strict'
 
 require('colors')
+const argv = require('yargs')
+  .option('onlyGrapes', {
+    alias: 'g',
+    type: 'boolean',
+    default: false
+  })
+  .help('help')
+  .argv
 
 const {
   startHelpers,
@@ -16,7 +24,10 @@ const grapes = []
 let ipcs = []
 
 const _processExit = async () => {
-  await closeIpc(ipcs)
+  if (!argv.onlyGrapes) {
+    await closeIpc(ipcs)
+  }
+
   await killGrapes(grapes)
 
   process.exit()
@@ -28,6 +39,10 @@ process.on('SIGTERM', _processExit)
 
 ;(async () => {
   try {
+    if (argv.onlyGrapes) {
+      console.log('[ONLY GRAPES]'.bgBlue)
+    }
+
     console.log('[WAIT]'.yellow)
 
     const _grapes = await bootTwoGrapes()
@@ -41,7 +56,9 @@ process.on('SIGTERM', _processExit)
       console.error('[ERR]: '.red, err.toString().red)
     })
 
-    ipcs = startHelpers(true)
+    if (!argv.onlyGrapes) {
+      ipcs = startHelpers(true)
+    }
 
     await new Promise((resolve, reject) => {
       grape1.once('error', reject)

--- a/workers/loc.api/queue/helpers/get-complete-file-name.js
+++ b/workers/loc.api/queue/helpers/get-complete-file-name.js
@@ -77,6 +77,12 @@ const _getDateString = mc => {
   return (new Date(mc)).toDateString().split(' ').join('-')
 }
 
+const _getUniqEnding = (uniqEnding = '') => {
+  return uniqEnding && typeof uniqEnding === 'string'
+    ? `-${uniqEnding}`
+    : `-${uuidv4()}`
+}
+
 module.exports = (
   queueName,
   params,
@@ -84,7 +90,8 @@ module.exports = (
     userInfo,
     ext = 'csv',
     isMultiExport,
-    isAddedUniqueEndingToCsvName
+    isAddedUniqueEndingToCsvName,
+    uniqEnding = ''
   } = {}
 ) => {
   const {
@@ -112,20 +119,20 @@ module.exports = (
     : formattedDateNow
   const _ext = ext ? `.${ext}` : ''
   const _userInfo = userInfo ? `${userInfo}_` : ''
-  const uniqEnding = isAddedUniqueEndingToCsvName
-    ? `-${uuidv4()}`
+  const _uniqEnding = isAddedUniqueEndingToCsvName
+    ? _getUniqEnding(uniqEnding)
     : ''
 
   if (isBaseNameInName) {
-    return `${_userInfo}${baseName}_${formattedDateNow}${uniqEnding}${_ext}`
+    return `${_userInfo}${baseName}_${formattedDateNow}${_uniqEnding}${_ext}`
   }
   if (
     queueName === 'getWallets' ||
     isMultiExport ||
     isOnMomentInName
   ) {
-    return `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${uniqEnding}${_ext}`
+    return `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${_uniqEnding}${_ext}`
   }
 
-  return `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${uniqEnding}${_ext}`
+  return `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${_uniqEnding}${_ext}`
 }

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -53,15 +53,11 @@ const moveFileToLocalStorage = async (
 
   await _checkAndCreateDir(localStorageDirPath)
 
-  const fileName = getCompleteFileName(
+  let fileName = getCompleteFileName(
     name,
     params,
-    {
-      userInfo,
-      isAddedUniqueEndingToCsvName
-    }
+    { userInfo }
   )
-  const newFilePath = path.join(localStorageDirPath, fileName)
 
   try {
     await access(filePath, fs.constants.F_OK | fs.constants.W_OK)
@@ -71,6 +67,24 @@ const moveFileToLocalStorage = async (
     } else throw err
   }
 
+  const files = await readdir(localStorageDirPath)
+  let count = 0
+
+  while (files.some(file => file === fileName)) {
+    count += 1
+
+    fileName = getCompleteFileName(
+      name,
+      params,
+      {
+        userInfo,
+        isAddedUniqueEndingToCsvName,
+        uniqEnding: `(${count})`
+      }
+    )
+  }
+
+  const newFilePath = path.join(localStorageDirPath, fileName)
   await rename(filePath, newFilePath)
 
   if (isElectronjsEnv) {


### PR DESCRIPTION
This PR changes CSV file name ending from UUID to serial number `-(1)` or `-(2)` etc
Adds an ability to simulate only grapes env using `npm run startSimulEnv -- -g`

For example:
  - before `user_ledgers_FROM_Thu-Jan-01-2019_TO_Mon-Jan-04-2021_ON_Mon-Jan-04-2021-0616d514-a865-4155-bbb0-c3e7ab53d7cc.csv`
  - after `user_ledgers_FROM_Thu-Jan-01-2019_TO_Mon-Jan-04-2021_ON_Mon-Jan-04-2021-(1).csv`