### PR TITLE
Add ability to put csv files into common folder

### DIFF
--- a/test/simulate/simulate-enviroment.js
+++ b/test/simulate/simulate-enviroment.js
@@ -1,6 +1,14 @@
 'use strict'
 
 require('colors')
+const argv = require('yargs')
+  .option('onlyGrapes', {
+    alias: 'g',
+    type: 'boolean',
+    default: false
+  })
+  .help('help')
+  .argv
 
 const {
   startHelpers,
@@ -16,7 +24,10 @@ const grapes = []
 let ipcs = []
 
 const _processExit = async () => {
-  await closeIpc(ipcs)
+  if (!argv.onlyGrapes) {
+    await closeIpc(ipcs)
+  }
+
   await killGrapes(grapes)
 
   process.exit()
@@ -28,6 +39,10 @@ process.on('SIGTERM', _processExit)
 
 ;(async () => {
   try {
+    if (argv.onlyGrapes) {
+      console.log('[ONLY GRAPES]'.bgBlue)
+    }
+
     console.log('[WAIT]'.yellow)
 
     const _grapes = await bootTwoGrapes()
@@ -41,7 +56,9 @@ process.on('SIGTERM', _processExit)
       console.error('[ERR]: '.red, err.toString().red)
     })
 
-    ipcs = startHelpers(true)
+    if (!argv.onlyGrapes) {
+      ipcs = startHelpers(true)
+    }
 
     await new Promise((resolve, reject) => {
       grape1.once('error', reject)

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -20,6 +20,7 @@ module.exports = (
   return async (job) => {
     try {
       const {
+        chunkCommonFolder,
         userInfo,
         name,
         filePaths,
@@ -74,7 +75,8 @@ module.exports = (
             subParamsArr[count].name || name,
             { ...subParamsArr[count] },
             userInfo.username,
-            isAddedUniqueEndingToCsvName
+            isAddedUniqueEndingToCsvName,
+            chunkCommonFolder
           )
 
           count += 1

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -65,26 +65,35 @@ module.exports = (
         for (const filePath of filePaths) {
           await unlink(filePath)
         }
-      } else {
-        let count = 0
 
-        for (const filePath of filePaths) {
-          await moveFileToLocalStorage(
-            rootPath,
-            filePath,
-            subParamsArr[count].name || name,
-            { ...subParamsArr[count] },
-            userInfo.username,
-            isAddedUniqueEndingToCsvName,
-            chunkCommonFolder
-          )
+        job.done()
+        aggregatorQueue.emit('completed')
 
-          count += 1
-        }
+        return
+      }
+
+      const newFilePaths = []
+      let count = 0
+
+      for (const filePath of filePaths) {
+        const {
+          newFilePath
+        } = await moveFileToLocalStorage(
+          rootPath,
+          filePath,
+          subParamsArr[count].name || name,
+          { ...subParamsArr[count] },
+          userInfo.username,
+          isAddedUniqueEndingToCsvName,
+          chunkCommonFolder
+        )
+
+        newFilePaths.push(newFilePath)
+        count += 1
       }
 
       job.done()
-      aggregatorQueue.emit('completed')
+      aggregatorQueue.emit('completed', { newFilePaths })
     } catch (err) {
       if (err.syscall === 'unlink') {
         aggregatorQueue.emit('error:unlink', job)

--- a/workers/loc.api/queue/helpers/get-complete-file-name.js
+++ b/workers/loc.api/queue/helpers/get-complete-file-name.js
@@ -77,6 +77,12 @@ const _getDateString = mc => {
   return (new Date(mc)).toDateString().split(' ').join('-')
 }
 
+const _getUniqEnding = (uniqEnding = '') => {
+  return uniqEnding && typeof uniqEnding === 'string'
+    ? `-${uniqEnding}`
+    : `-${uuidv4()}`
+}
+
 module.exports = (
   queueName,
   params,
@@ -84,7 +90,8 @@ module.exports = (
     userInfo,
     ext = 'csv',
     isMultiExport,
-    isAddedUniqueEndingToCsvName
+    isAddedUniqueEndingToCsvName,
+    uniqEnding = ''
   } = {}
 ) => {
   const {
@@ -112,20 +119,20 @@ module.exports = (
     : formattedDateNow
   const _ext = ext ? `.${ext}` : ''
   const _userInfo = userInfo ? `${userInfo}_` : ''
-  const uniqEnding = isAddedUniqueEndingToCsvName
-    ? `-${uuidv4()}`
+  const _uniqEnding = isAddedUniqueEndingToCsvName
+    ? _getUniqEnding(uniqEnding)
     : ''
 
   if (isBaseNameInName) {
-    return `${_userInfo}${baseName}_${formattedDateNow}${uniqEnding}${_ext}`
+    return `${_userInfo}${baseName}_${formattedDateNow}${_uniqEnding}${_ext}`
   }
   if (
     queueName === 'getWallets' ||
     isMultiExport ||
     isOnMomentInName
   ) {
-    return `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${uniqEnding}${_ext}`
+    return `${_userInfo}${baseName}_MOMENT_${formattedDateNow}${_uniqEnding}${_ext}`
   }
 
-  return `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${uniqEnding}${_ext}`
+  return `${_userInfo}${baseName}_FROM_${startDate}_TO_${endDate}_ON_${timestamp}${_uniqEnding}${_ext}`
 }

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -17,25 +17,28 @@ const isElectronjsEnv = argv.isElectronjsEnv
 const getCompleteFileName = require('./get-complete-file-name')
 
 const _checkAndCreateDir = async (dirPath) => {
-  const basePath = path.join(dirPath, '..')
-
   try {
     await access(dirPath, fs.constants.F_OK | fs.constants.W_OK)
   } catch (err) {
-    if (err.code === 'EACCES' && !isElectronjsEnv) throw err
     if (err.code === 'ENOENT') {
-      try {
-        await access(basePath, fs.constants.F_OK | fs.constants.W_OK)
-      } catch (errBasePath) {
-        if (errBasePath.code === 'EACCES' && isElectronjsEnv) {
-          await chmod(basePath, '766')
-        }
+      await mkdir(dirPath, { recursive: true })
+
+      if (isElectronjsEnv) {
+        await chmod(dirPath, '766')
       }
 
-      await mkdir(dirPath, { recursive: true })
+      return
+    }
+    if (
+      err.code === 'EACCES' &&
+      isElectronjsEnv
+    ) {
+      await chmod(dirPath, '766')
+
+      return
     }
 
-    if (isElectronjsEnv) await chmod(dirPath, '766')
+    throw err
   }
 }
 

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -97,6 +97,8 @@ const moveFileToLocalStorage = async (
   if (isElectronjsEnv) {
     await chmod(newFilePath, '766')
   }
+
+  return { newFilePath }
 }
 
 const createUniqueFileName = async (rootPath, count = 0) => {

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -32,7 +32,7 @@ const _checkAndCreateDir = async (dirPath) => {
         } else throw errBasePath
       }
 
-      await mkdir(dirPath)
+      await mkdir(dirPath, { recursive: true })
     }
 
     if (isElectronjsEnv) await chmod(dirPath, '766')
@@ -45,13 +45,20 @@ const moveFileToLocalStorage = async (
   name,
   params,
   userInfo,
-  isAddedUniqueEndingToCsvName
+  isAddedUniqueEndingToCsvName,
+  chunkCommonFolder
 ) => {
   const localStorageDirPath = path.isAbsolute(argv.csvFolder)
     ? argv.csvFolder
     : path.join(rootPath, argv.csvFolder)
+  const fullCsvDirPath = (
+    chunkCommonFolder &&
+    typeof chunkCommonFolder === 'string'
+  )
+    ? path.join(localStorageDirPath, chunkCommonFolder)
+    : localStorageDirPath
 
-  await _checkAndCreateDir(localStorageDirPath)
+  await _checkAndCreateDir(fullCsvDirPath)
 
   let fileName = getCompleteFileName(
     name,
@@ -67,7 +74,7 @@ const moveFileToLocalStorage = async (
     } else throw err
   }
 
-  const files = await readdir(localStorageDirPath)
+  const files = await readdir(fullCsvDirPath)
   let count = 0
 
   while (files.some(file => file === fileName)) {
@@ -84,7 +91,7 @@ const moveFileToLocalStorage = async (
     )
   }
 
-  const newFilePath = path.join(localStorageDirPath, fileName)
+  const newFilePath = path.join(fullCsvDirPath, fileName)
   await rename(filePath, newFilePath)
 
   if (isElectronjsEnv) {

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -53,15 +53,11 @@ const moveFileToLocalStorage = async (
 
   await _checkAndCreateDir(localStorageDirPath)
 
-  const fileName = getCompleteFileName(
+  let fileName = getCompleteFileName(
     name,
     params,
-    {
-      userInfo,
-      isAddedUniqueEndingToCsvName
-    }
+    { userInfo }
   )
-  const newFilePath = path.join(localStorageDirPath, fileName)
 
   try {
     await access(filePath, fs.constants.F_OK | fs.constants.W_OK)
@@ -71,6 +67,24 @@ const moveFileToLocalStorage = async (
     } else throw err
   }
 
+  const files = await readdir(localStorageDirPath)
+  let count = 0
+
+  while (files.some(file => file === fileName)) {
+    count += 1
+
+    fileName = getCompleteFileName(
+      name,
+      params,
+      {
+        userInfo,
+        isAddedUniqueEndingToCsvName,
+        uniqEnding: `(${count})`
+      }
+    )
+  }
+
+  const newFilePath = path.join(localStorageDirPath, fileName)
   await rename(filePath, newFilePath)
 
   if (isElectronjsEnv) {

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -29,7 +29,7 @@ const _checkAndCreateDir = async (dirPath) => {
       } catch (errBasePath) {
         if (errBasePath.code === 'EACCES' && isElectronjsEnv) {
           await chmod(basePath, '766')
-        } else throw errBasePath
+        }
       }
 
       await mkdir(dirPath, { recursive: true })

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -59,6 +59,7 @@ module.exports = (
       job.data.args.params = { ...job.data.args.params }
 
       const {
+        chunkCommonFolder,
         userInfo,
         userId,
         name,
@@ -125,6 +126,7 @@ module.exports = (
 
       job.done()
       processorQueue.emit('completed', {
+        chunkCommonFolder,
         userInfo,
         userId,
         name,


### PR DESCRIPTION
This PR adds an ability to put csv files into common folder, for each tax export, create a folder and add the 3 files inside there. Basic changes:
  - Adds ability to put csv files into a common folder
  - Adds test coverage for csv files storing in a common local folder
  - Fixes recursive creating csv folder

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/203